### PR TITLE
Do not create conversation channel on list item creation

### DIFF
--- a/src/com/android/messaging/datamodel/data/PeopleOptionsItemData.java
+++ b/src/com/android/messaging/datamodel/data/PeopleOptionsItemData.java
@@ -17,15 +17,11 @@ package com.android.messaging.datamodel.data;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.media.Ringtone;
-import android.media.RingtoneManager;
-import android.net.Uri;
 
 import com.android.messaging.R;
 import com.android.messaging.datamodel.data.ConversationListItemData.ConversationListViewColumns;
 import com.android.messaging.util.Assert;
 import com.android.messaging.util.NotificationChannelUtil;
-import com.android.messaging.util.RingtoneUtil;
 
 public class PeopleOptionsItemData {
     public static final String[] PROJECTION = {
@@ -59,6 +55,10 @@ public class PeopleOptionsItemData {
     private boolean mEnabled;
     private int mItemId;
     private ParticipantData mOtherParticipant;
+    private String mConversationTitle;
+    private boolean mLegacyNotificationEnabled;
+    private String mLegacyRingtoneString;
+    private boolean mLegacyVibrationEnabled;
 
     private final Context mContext;
 
@@ -78,30 +78,15 @@ public class PeopleOptionsItemData {
         mEnabled = true;
         mItemId = settingType;
         mOtherParticipant = otherParticipant;
+        mConversationTitle = cursor.getString(INDEX_CONVERSATION_NAME);
+        mLegacyVibrationEnabled = cursor.getInt(INDEX_NOTIFICATION_ENABLED) == 1;
+        mLegacyRingtoneString = cursor.getString(INDEX_NOTIFICATION_SOUND_URI);
+        mLegacyVibrationEnabled = cursor.getInt(INDEX_NOTIFICATION_VIBRATION) == 1;
 
         switch (settingType) {
             case SETTING_NOTIFICATIONS:
                 mTitle = mContext.getString(R.string.notifications_enabled_conversation_pref_title);
                 mCheckable = false;
-
-                final String conversationId = cursor.getString(INDEX_CONVERSATION_ID);
-
-                final String conversationTitle = cursor.getString(INDEX_CONVERSATION_NAME);
-
-                final boolean legacyNotificationEnabled =
-                        cursor.getInt(INDEX_NOTIFICATION_ENABLED) == 1;
-
-                final String legacyRingtoneString = cursor.getString(INDEX_NOTIFICATION_SOUND_URI);
-
-                final boolean legacyVibrationEnabled = cursor.getInt(INDEX_NOTIFICATION_VIBRATION) == 1;
-
-                NotificationChannelUtil.INSTANCE.createConversationChannel(
-                        conversationId,
-                        conversationTitle,
-                        legacyNotificationEnabled,
-                        legacyRingtoneString,
-                        legacyVibrationEnabled
-                );
                 break;
 
             case SETTING_BLOCKED:
@@ -139,6 +124,22 @@ public class PeopleOptionsItemData {
 
     public int getItemId() {
         return mItemId;
+    }
+
+    public String getConversationTitle() {
+        return mConversationTitle;
+    }
+
+    public boolean getLegacyNotificationEnabled() {
+        return mLegacyNotificationEnabled;
+    }
+
+    public String getLegacyRingtoneString() {
+        return mLegacyRingtoneString;
+    }
+
+    public boolean getLegacyVibrationEnabled() {
+        return mLegacyVibrationEnabled;
     }
 
     public ParticipantData getOtherParticipant() {

--- a/src/com/android/messaging/ui/conversationsettings/PeopleAndOptionsFragment.java
+++ b/src/com/android/messaging/ui/conversationsettings/PeopleAndOptionsFragment.java
@@ -47,6 +47,7 @@ import com.android.messaging.ui.CompositeAdapter;
 import com.android.messaging.ui.PersonItemView;
 import com.android.messaging.ui.conversation.ConversationActivity;
 import com.android.messaging.util.Assert;
+import com.android.messaging.util.NotificationChannelUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -119,6 +120,14 @@ public class PeopleAndOptionsFragment extends Fragment
             final boolean isChecked) {
         switch (item.getItemId()) {
             case PeopleOptionsItemData.SETTING_NOTIFICATIONS:
+                NotificationChannelUtil.INSTANCE.createConversationChannel(
+                        mBinding.getData().getConversationId(),
+                        item.getConversationTitle(),
+                        item.getLegacyNotificationEnabled(),
+                        item.getLegacyRingtoneString(),
+                        item.getLegacyVibrationEnabled()
+                );
+
                 Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
                         .putExtra(Settings.EXTRA_APP_PACKAGE, getContext().getPackageName())
                         .putExtra(Settings.EXTRA_CHANNEL_ID, mBinding.getData().getConversationId())


### PR DESCRIPTION
Moves conversation channel creation logic to when the user clicks the "Notifications" button