### PR TITLE
Process message data for secondary users

### DIFF
--- a/src/com/android/messaging/datamodel/data/ConversationListData.java
+++ b/src/com/android/messaging/datamodel/data/ConversationListData.java
@@ -176,8 +176,6 @@ public class ConversationListData extends BindableData
 
     public void handleMessagesSeen() {
         BugleNotifications.markAllMessagesAsSeen();
-
-        SmsReceiver.cancelSecondaryUserNotification();
     }
 
     @Override

--- a/src/com/android/messaging/receiver/SmsReceiver.java
+++ b/src/com/android/messaging/receiver/SmsReceiver.java
@@ -16,42 +16,28 @@
 
 package com.android.messaging.receiver;
 
-import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.content.res.Resources;
 import android.provider.Telephony;
 import android.provider.Telephony.Sms;
 
 import com.android.messaging.Factory;
-import com.android.messaging.R;
-import com.android.messaging.datamodel.BugleNotifications;
-import com.android.messaging.datamodel.MessageNotificationState;
 import com.android.messaging.datamodel.action.ReceiveSmsMessageAction;
 import com.android.messaging.sms.MmsUtils;
-import com.android.messaging.ui.UIIntents;
 import com.android.messaging.util.BugleGservices;
 import com.android.messaging.util.BugleGservicesKeys;
 import com.android.messaging.util.DebugUtils;
 import com.android.messaging.util.LogUtil;
-import com.android.messaging.util.NotificationChannelUtil;
 import com.android.messaging.util.OsUtil;
-import com.android.messaging.util.PendingIntentConstants;
 import com.android.messaging.util.PhoneUtils;
 
 import java.util.ArrayList;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
-import androidx.core.app.NotificationCompat;
-import androidx.core.app.NotificationCompat.Builder;
-import androidx.core.app.NotificationCompat.Style;
-import androidx.core.app.NotificationManagerCompat;
 
 /**
  * Class that receives incoming SMS messages through android.provider.Telephony.SMS_RECEIVED
@@ -157,57 +143,9 @@ public final class SmsReceiver extends BroadcastReceiver {
                     (Telephony.Sms.Intents.SMS_RECEIVED_ACTION.equals(action) ||
                             // TODO: update this with the actual constant from Telephony
                             "android.provider.Telephony.MMS_DOWNLOADED".equals(action))) {
-                postNewMessageSecondaryUserNotification();
+                deliverSmsIntent(context, intent);
             }
         }
-    }
-
-    private static class SecondaryUserNotificationState extends MessageNotificationState {
-        SecondaryUserNotificationState() {
-            super(null);
-        }
-    }
-
-    public static void postNewMessageSecondaryUserNotification() {
-        final Context context = Factory.get().getApplicationContext();
-        final Resources resources = context.getResources();
-        final PendingIntent pendingIntent = UIIntents.get()
-                .getPendingIntentForSecondaryUserNewMessageNotification(context);
-
-        final NotificationCompat.Builder builder =
-                new NotificationCompat.Builder(context, NotificationChannelUtil.INCOMING_MESSAGES);
-        builder.setContentTitle(resources.getString(R.string.secondary_user_new_message_title))
-                .setTicker(resources.getString(R.string.secondary_user_new_message_ticker))
-                .setSmallIcon(R.drawable.ic_sms_light)
-        // Returning PRIORITY_HIGH causes L to put up a HUD notification. Without it, the ticker
-        // isn't displayed.
-                .setPriority(Notification.PRIORITY_HIGH)
-                .setContentIntent(pendingIntent);
-
-        final NotificationCompat.BigTextStyle bigTextStyle =
-                new NotificationCompat.BigTextStyle(builder);
-        bigTextStyle.bigText(resources.getString(R.string.secondary_user_new_message_title));
-        final Notification notification = bigTextStyle.build();
-
-        final NotificationManagerCompat notificationManager =
-                NotificationManagerCompat.from(Factory.get().getApplicationContext());
-
-        notificationManager.notify(getNotificationTag(),
-                PendingIntentConstants.SMS_SECONDARY_USER_NOTIFICATION_ID, notification);
-    }
-
-    /**
-     * Cancel the notification
-     */
-    public static void cancelSecondaryUserNotification() {
-        final NotificationManagerCompat notificationManager =
-                NotificationManagerCompat.from(Factory.get().getApplicationContext());
-        notificationManager.cancel(getNotificationTag(),
-                PendingIntentConstants.SMS_SECONDARY_USER_NOTIFICATION_ID);
-    }
-
-    private static String getNotificationTag() {
-        return Factory.get().getApplicationContext().getPackageName() + ":secondaryuser";
     }
 
     /**


### PR DESCRIPTION
Makes it so that intents for messages received when using a secondary user use the same path as the owner

Untested for MMS messages or on a real device

[Screencast from 2025-06-08 16-13-15.webm](https://github.com/user-attachments/assets/d320bcb6-1d1d-448f-85b0-387a6ebe19b9)
