### PR TITLE
Actually bump the minimum and target SDK to 36, since it seems to have been forgotten

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
     defaultConfig {
         versionCode = 20000000 + 13
         versionName = "13"
-        minSdk = 35
-        targetSdk = 35
+        minSdk = 36
+        targetSdk = 36
 
         ndk {
             abiFilters.clear()


### PR DESCRIPTION
Not incrementing the version number, since no changes have been made since the increment to 13, and version 13 hasn't been released yet