### PR TITLE
Add a warning about sms/mms insecurity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -90,6 +90,11 @@
             android:screenOrientation="portrait"
             android:configChanges="orientation|screenSize|keyboardHidden" />
 
+        <activity
+            android:name=".ui.WelcomeSMSWarningActivity"
+            android:screenOrientation="portrait"
+            android:configChanges="orientation|screenSize|keyboardHidden" />
+
         <!-- Launches a conversation (ensures correct app name shown in recents) -->
         <activity
             android:name=".ui.conversation.LaunchConversationActivity"

--- a/res/layout/welcome_sms_warning.xml
+++ b/res/layout/welcome_sms_warning.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2015 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/permission_check_activity_background"
+    android:orientation="vertical">
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/welcome_sms_warning_title"
+        android:paddingTop="64dp"
+        style="@style/PromoScreenTextStyle.CenterAligned"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:text="@string/welcome_sms_warning_description"
+        style="@style/PromoScreenTextStyle.CenterAligned" />
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:adjustViewBounds="true"
+        android:paddingTop="40dp"
+        android:src="@drawable/ic_launcher_foreground"
+        android:scaleType="centerCrop"
+        android:importantForAccessibility="no"
+        app:tint="@android:color/white" />
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@android:color/white" />
+    <!-- Buttons -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:orientation="horizontal" >
+        <TextView
+            android:id="@+id/exit"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="@string/exit"
+            android:contentDescription="@string/exit"
+            style="@style/PromoScreenButtonStyle" />
+        <TextView
+            android:id="@+id/next"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="@string/next_with_arrow"
+            android:contentDescription="@string/next"
+            style="@style/PromoScreenButtonStyle" />
+    </LinearLayout>
+</LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -35,6 +35,9 @@
     <string name="exit">Exit</string>
     <string name="settings_with_arrow">Settings &gt;</string>
     <string name="settings">Settings</string>
+    <!-- Warn user that sms/mms is insecure and shouldn't be used. -->
+    <string name="welcome_sms_warning_title">Welcome to the latest version of the Graphene OS Messaging App!</string>
+    <string name="welcome_sms_warning_description">Please note that <xliff:g id="sms_mms">SMS/MMS</xliff:g> are a non-private and insecure form of communication. We highly recommend using a more secure and private service, such as <xliff:g id="app">Molly/Signal</xliff:g>.</string>
     <!-- Inform user of the names of permissions that are required to use the app -->
     <string name="required_permissions_promo">Messaging needs permission to SMS, Phone and Contacts.</string>
     <string name="enable_permission_procedure">You can change permissions in Settings > Apps > Messaging > Permissions.</string>

--- a/src/com/android/messaging/ui/BaseBugleActivity.java
+++ b/src/com/android/messaging/ui/BaseBugleActivity.java
@@ -32,7 +32,7 @@ public class BaseBugleActivity extends AppCompatActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (UiUtils.redirectToPermissionCheckIfNeeded(this)) {
+        if (UiUtils.checkToShowWelcomeAndPermissionScreens(this)) {
             return;
         }
     }

--- a/src/com/android/messaging/ui/BugleActionBarActivity.java
+++ b/src/com/android/messaging/ui/BugleActionBarActivity.java
@@ -61,7 +61,7 @@ public class BugleActionBarActivity extends AppCompatActivity implements ImeUtil
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (UiUtils.redirectToPermissionCheckIfNeeded(this)) {
+        if (UiUtils.checkToShowWelcomeAndPermissionScreens(this)) {
             return;
         }
 

--- a/src/com/android/messaging/ui/UIIntents.java
+++ b/src/com/android/messaging/ui/UIIntents.java
@@ -115,6 +115,12 @@ public abstract class UIIntents {
      */
     public abstract void launchPermissionCheckActivity(final Context context);
 
+    /**
+     * Launch the welcome and warning activity
+     */
+
+    public abstract void launchWelcomeSMSWarningActivity(final Context context);
+
     public abstract void launchConversationListActivity(final Context context);
 
     /**

--- a/src/com/android/messaging/ui/UIIntentsImpl.java
+++ b/src/com/android/messaging/ui/UIIntentsImpl.java
@@ -137,6 +137,14 @@ public class UIIntentsImpl extends UIIntents {
     @Override
     public void launchPermissionCheckActivity(final Context context) {
         final Intent intent = new Intent(context, PermissionCheckActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        context.startActivity(intent);
+    }
+
+    @Override
+    public void launchWelcomeSMSWarningActivity(final Context context) {
+        final Intent intent = new Intent(context, WelcomeSMSWarningActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         context.startActivity(intent);
     }
 

--- a/src/com/android/messaging/ui/WelcomeSMSWarningActivity.java
+++ b/src/com/android/messaging/ui/WelcomeSMSWarningActivity.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.messaging.ui;
+
+import static com.android.messaging.util.BuglePrefs.KEY_LAST_VERSION;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.activity.OnBackPressedCallback;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.android.messaging.BuildConfig;
+import com.android.messaging.R;
+import com.android.messaging.util.BuglePrefs;
+import com.android.messaging.util.UiUtils;
+
+/**
+ * Activity to warn user that sms/mms is insecure and should not be used.
+ */
+public class WelcomeSMSWarningActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.welcome_sms_warning);
+        UiUtils.setStatusBarColor(this, getColor(R.color.permission_check_activity_background));
+
+        // Remove title bar added by AppCompatActivity
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().hide();
+        }
+
+        findViewById(R.id.exit).setOnClickListener(view -> finish());
+
+        final BuglePrefs prefs = BuglePrefs.getApplicationPrefs();
+
+        TextView mNextView = findViewById(R.id.next);
+        mNextView.setVisibility(View.VISIBLE);
+
+        mNextView.setOnClickListener(v -> {
+            UIIntents.get().launchPermissionCheckActivity(this);
+            prefs.putInt(KEY_LAST_VERSION, BuildConfig.VERSION_CODE);
+            finish();
+        });
+
+        OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                finish();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, callback);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+    }
+}

--- a/src/com/android/messaging/ui/conversation/LaunchConversationActivity.java
+++ b/src/com/android/messaging/ui/conversation/LaunchConversationActivity.java
@@ -57,7 +57,7 @@ public class LaunchConversationActivity extends Activity implements
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (UiUtils.redirectToPermissionCheckIfNeeded(this)) {
+        if (UiUtils.checkToShowWelcomeAndPermissionScreens(this)) {
             return;
         }
 

--- a/src/com/android/messaging/util/BuglePrefs.java
+++ b/src/com/android/messaging/util/BuglePrefs.java
@@ -41,6 +41,8 @@ public abstract class BuglePrefs {
      */
     public static final int NO_SHARED_PREFERENCES_VERSION = -1;
 
+    public static final String KEY_LAST_VERSION = "last_version";
+
     /**
      * Returns the shared preferences file name to use.
      * Subclasses should override and return the shared preferences file.

--- a/src/com/android/messaging/util/UiUtils.java
+++ b/src/com/android/messaging/util/UiUtils.java
@@ -16,6 +16,9 @@
 
 package com.android.messaging.util;
 
+import static com.android.messaging.util.BuglePrefs.KEY_LAST_VERSION;
+import static com.android.messaging.util.BuglePrefs.NO_SHARED_PREFERENCES_VERSION;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
@@ -40,6 +43,7 @@ import android.view.animation.ScaleAnimation;
 import android.widget.RemoteViews;
 import android.widget.Toast;
 
+import com.android.messaging.BuildConfig;
 import com.android.messaging.Factory;
 import com.android.messaging.R;
 import com.android.messaging.ui.SnackBar;
@@ -303,6 +307,23 @@ public class UiUtils {
     }
 
     /**
+     * Check if app has just been updated, so we can show the launchWelcomeSMSWarningActivity
+     */
+
+    public static boolean isFirstRunAfterUpdate(final Activity activity) {
+        final BuglePrefs prefs = BuglePrefs.getApplicationPrefs();
+
+        final int savedVersion = prefs.getInt(KEY_LAST_VERSION, NO_SHARED_PREFERENCES_VERSION);
+        final int currentVersion = BuildConfig.VERSION_CODE;
+
+        if (currentVersion != savedVersion) {
+            UIIntents.get().launchWelcomeSMSWarningActivity(activity);
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Check if the activity needs to be redirected to permission check
      * @return true if {@link Activity#finish()} was called because redirection was performed
      */
@@ -317,6 +338,19 @@ public class UiUtils {
         // Redirect performed
         activity.finish();
         return true;
+    }
+
+    /**
+     * Checks whether or not to show the welcome/warning activity,
+     * and then checks whether or not to show the permission activity
+     * @param activity The current activity context
+     * @return true if either the welcome screen or permission check screen is shown
+     */
+    public static boolean checkToShowWelcomeAndPermissionScreens (Activity activity) {
+        if (UiUtils.isFirstRunAfterUpdate(activity)) {
+            return true;
+        }
+        return UiUtils.redirectToPermissionCheckIfNeeded(activity);
     }
 
     /**


### PR DESCRIPTION
Right now, shows a screen at app launch on each new version, with a welcome heading, and warning about SMS/MMS.
The only thing I am not sure about if showing it after every version would be to annoying for the user. I considered putting it as a dialog/snackbar/card, but couldn't figuring out a way that would be noticeable but not annoying. 
Closes #47 