### PR TITLE
Fix regression preventing unread notifications to survive reboot

### DIFF
--- a/src/com/android/messaging/datamodel/BugleNotifications.java
+++ b/src/com/android/messaging/datamodel/BugleNotifications.java
@@ -123,14 +123,11 @@ public class BugleNotifications {
     Assert.isNotMainThread();
 
         if (!shouldNotify()) {
+            cancel(PendingIntentConstants.SMS_NOTIFICATION_ID);
             return;
         }
         if ((coverage & UPDATE_MESSAGES) != 0) {
-            if (conversationId == null) {
-                cancel(PendingIntentConstants.SMS_NOTIFICATION_ID);
-            } else {
-                createMessageNotification(conversationId);
-            }
+            createMessageNotification(conversationId);
         }
         if ((coverage & UPDATE_ERRORS) != 0) {
             MessageNotificationState.checkFailedMessages();


### PR DESCRIPTION
Fixes #83, a regression that happened with PR #35 
With the auto reboot feature, it's really important that notifications can persist when  you can't see the notification before the reboot.