### PR TITLE
fix: display phone number for unknown group chat senders

### DIFF
--- a/src/com/android/messaging/datamodel/MessageNotificationState.java
+++ b/src/com/android/messaging/datamodel/MessageNotificationState.java
@@ -487,10 +487,9 @@ public class MessageNotificationState {
                     // Prepare the message line
                     if (conversation.mIsGroup) {
                         if (authorFirstName == null) {
-                            // authorFullName might be null as well. In that case, we won't
-                            // show an author. That is better than showing all the group
-                            // names again on the 2nd line.
-                            authorFirstName = authorFullName;
+                            authorFirstName = authorFullName != null
+                                    ? authorFullName
+                                    : convMessageData.getSenderDisplayDestination();
                         }
                     } else {
                         // don't recompute this if we don't need to


### PR DESCRIPTION
- Closes #67

### Problem

In group conversations, the author first name is computed by using the author's full name, however, this fails when the author is null (which is the case for numbers not added as a contact). This leads to notifications from any number not in your contacts in a group conversation show up as being from "null", which is wrong.

### Solution

I've set the author's first name to be the phone number of the sender as a fallback, which fixes notifications from this number. The screenshots below show the visual change before & after this PR.

Before:
<img width="843" height="219" alt="image" src="https://github.com/user-attachments/assets/58a8e7bd-14ae-4dfc-8b92-a00ac141febb" />

After:
<img width="853" height="224" alt="image" src="https://github.com/user-attachments/assets/719f96be-09b5-476d-9a27-8a66dc4093c2" />

The unknown number ending in 8 now properly displays itself as the sender of a given message in notifications.