### PR TITLE
security: add FLAG_IMMUTABLE to PendingIntents

### DIFF
--- a/src/com/android/messaging/datamodel/action/ActionServiceImpl.java
+++ b/src/com/android/messaging/datamodel/action/ActionServiceImpl.java
@@ -201,8 +201,11 @@ public class ActionServiceImpl extends JobIntentService {
         if (launchesAnActivity) {
             intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
         }
+        // Use FLAG_IMMUTABLE since this PendingIntent doesn't require modification.
+        // This prevents potential PendingIntent hijacking attacks.
+        // Reference: https://developer.android.com/reference/android/app/PendingIntent#FLAG_IMMUTABLE
         return PendingIntent.getBroadcast(context, requestCode, intent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
     }
 
     /**

--- a/src/com/android/messaging/ui/UIIntentsImpl.java
+++ b/src/com/android/messaging/ui/UIIntentsImpl.java
@@ -483,8 +483,10 @@ public class UIIntentsImpl extends UIIntents {
         taskStackBuilder.addNextIntentWithParentStack(
                 getSmsStorageLowWarningActivityIntent(context));
 
+        // Use FLAG_IMMUTABLE since this PendingIntent launches a fixed activity
+        // and doesn't require modification by external apps.
         return taskStackBuilder.getPendingIntent(
-                0, PendingIntent.FLAG_UPDATE_CURRENT);
+                0, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
     }
 
     @Override


### PR DESCRIPTION
## Summary
Add `FLAG_IMMUTABLE` to PendingIntents in `ActionServiceImpl` and `UIIntentsImpl` to prevent potential PendingIntent hijacking attacks.
## Problem
Two PendingIntents were created with `FLAG_UPDATE_CURRENT` alone, without specifying mutability:
- `ActionServiceImpl.makeStartActionPendingIntent()`
- `UIIntentsImpl.getPendingIntentForLowStorageNotifications()`
Starting from Android 12, apps must explicitly specify the mutability of PendingIntents. Without `FLAG_IMMUTABLE`, a malicious app could potentially modify the PendingIntent before it's delivered, leading to:
- Intent redirection attacks
- Data tampering
- Privilege escalation
## Solution
Added `FLAG_IMMUTABLE` to both PendingIntents since they:
- Don't require fill-in data from the OS
- Launch fixed activities/broadcasts
- Don't need modification by external apps