### PR TITLE
Add `@Preview`s for the Conversation screen

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -11,6 +11,11 @@ complexity:
     allowedFunctionsPerInterface: 50
     ignoreAnnotatedFunctions:
       - Preview
+      - PreviewLightDark
+  LongMethod:
+    ignoreAnnotated:
+      - Preview
+      - PreviewLightDark
 
 naming:
   FunctionNaming:
@@ -30,3 +35,4 @@ style:
   UnusedPrivateFunction:
     ignoreAnnotated:
       - Preview
+      - PreviewLightDark

--- a/src/com/android/messaging/ui/appsettings/common/SettingsComponents.kt
+++ b/src/com/android/messaging/ui/appsettings/common/SettingsComponents.kt
@@ -25,10 +25,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.android.messaging.ui.core.AppTheme
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private const val DISABLED_ALPHA = 0.38f
 
@@ -173,10 +173,10 @@ private fun SettingsItemLayout(
     }
 }
 
-@Preview(showBackground = true)
+@PreviewLightDark
 @Composable
 private fun SettingsClickableItemPreview() {
-    AppTheme {
+    MessagingPreviewColumn {
         Column {
             SettingsClickableItem(
                 title = "Language",
@@ -205,20 +205,20 @@ private fun SettingsClickableItemPreview() {
     }
 }
 
-@Preview(showBackground = true)
+@PreviewLightDark
 @Composable
 private fun SettingsCategoryHeaderPreview() {
-    AppTheme {
+    MessagingPreviewColumn {
         SettingsCategoryHeader(
             title = "MMS Messaging",
         )
     }
 }
 
-@Preview(showBackground = true)
+@PreviewLightDark
 @Composable
 private fun SettingsSwitchItemPreview() {
-    AppTheme {
+    MessagingPreviewColumn {
         Column {
             SettingsSwitchItem(
                 title = "Auto-retrieve MMS",

--- a/src/com/android/messaging/ui/appsettings/common/SettingsTopAppBar.kt
+++ b/src/com/android/messaging/ui/appsettings/common/SettingsTopAppBar.kt
@@ -7,10 +7,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.android.messaging.R
+import com.android.messaging.ui.core.MessagingPreviewTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,4 +36,17 @@ internal fun SettingsTopAppBar(
         },
         scrollBehavior = scrollBehavior,
     )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewLightDark
+@Composable
+private fun SettingsTopAppBarPreview() {
+    MessagingPreviewTheme {
+        SettingsTopAppBar(
+            title = "Settings",
+            onNavigateBack = {},
+            scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(),
+        )
+    }
 }

--- a/src/com/android/messaging/ui/appsettings/general/ui/AppSettingsScreen.kt
+++ b/src/com/android/messaging/ui/appsettings/general/ui/AppSettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.android.messaging.R
 import com.android.messaging.ui.appsettings.common.SettingsCategoryHeader
 import com.android.messaging.ui.appsettings.common.SettingsClickableItem
@@ -19,6 +20,7 @@ import com.android.messaging.ui.appsettings.common.SettingsSwitchItem
 import com.android.messaging.ui.appsettings.common.SettingsTopAppBar
 import com.android.messaging.ui.appsettings.general.model.AppSettingsUiState
 import com.android.messaging.ui.appsettings.screen.model.SettingsAction as Action
+import com.android.messaging.ui.core.MessagingPreviewTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -161,6 +163,43 @@ private fun LazyListScope.licenseSettingsItems(
             onClick = {
                 onAction(Action.LicensesClicked)
             },
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun AppSettingsScreenTopLevelPreview() {
+    MessagingPreviewTheme {
+        AppSettingsScreen(
+            appSettings = AppSettingsUiState(
+                isDefaultSmsApp = true,
+                defaultSmsAppLabel = "Messaging",
+                sendSoundEnabled = true,
+            ),
+            onAction = {},
+            onNavigateBack = {},
+            isTopLevel = true,
+            onAdvancedClick = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun AppSettingsScreenDebugPreview() {
+    MessagingPreviewTheme {
+        AppSettingsScreen(
+            appSettings = AppSettingsUiState(
+                isDefaultSmsApp = false,
+                defaultSmsAppLabel = "Phone",
+                sendSoundEnabled = false,
+                isDebugEnabled = true,
+                dumpSmsEnabled = true,
+                dumpMmsEnabled = false,
+            ),
+            onAction = {},
+            onNavigateBack = {},
         )
     }
 }

--- a/src/com/android/messaging/ui/appsettings/screen/SettingsMainScreen.kt
+++ b/src/com/android/messaging/ui/appsettings/screen/SettingsMainScreen.kt
@@ -12,11 +12,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.android.messaging.R
 import com.android.messaging.ui.appsettings.common.SettingsClickableItem
 import com.android.messaging.ui.appsettings.common.SettingsTopAppBar
 import com.android.messaging.ui.appsettings.subscription.model.SubscriptionUiState
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -70,5 +73,42 @@ internal fun SettingsMainScreen(
                 }
             }
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SettingsMainScreenSingleSimPreview() {
+    MessagingPreviewTheme {
+        SettingsMainScreen(
+            subscriptions = persistentListOf(),
+            onNavigateBack = {},
+            onGeneralSettingsClick = {},
+            onSubscriptionClick = { _, _ -> },
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SettingsMainScreenMultiSimPreview() {
+    MessagingPreviewTheme {
+        SettingsMainScreen(
+            subscriptions = persistentListOf(
+                SubscriptionUiState(
+                    subId = 1,
+                    displayName = "SIM 1",
+                    displayDetail = "+31 6 1234 5678",
+                ),
+                SubscriptionUiState(
+                    subId = 2,
+                    displayName = "Travel SIM",
+                    displayDetail = "+372 5555 0101",
+                ),
+            ),
+            onNavigateBack = {},
+            onGeneralSettingsClick = {},
+            onSubscriptionClick = { _, _ -> },
+        )
     }
 }

--- a/src/com/android/messaging/ui/appsettings/screen/SettingsScreen.kt
+++ b/src/com/android/messaging/ui/appsettings/screen/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -29,7 +30,9 @@ import com.android.messaging.ui.appsettings.screen.model.SettingsNavRoute
 import com.android.messaging.ui.appsettings.screen.model.SettingsUiState
 import com.android.messaging.ui.appsettings.subscription.model.SubscriptionUiState
 import com.android.messaging.ui.appsettings.subscription.ui.SubscriptionSettingsScreen
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 private const val SLIDE_OFFSET_DIVISOR = 3
 
@@ -255,4 +258,83 @@ private fun advancedClickHandler(
         ?.let { sub ->
             { onRouteChange(SettingsNavRoute.SubscriptionSettings(sub.subId, sub.displayName)) }
         }
+}
+
+@PreviewLightDark
+@Composable
+private fun SettingsNavHostMainPreview() {
+    MessagingPreviewTheme {
+        SettingsNavHost(
+            effectiveRoute = SettingsNavRoute.Main,
+            uiState = previewSettingsUiState(),
+            onAction = {},
+            onNavigateBack = {},
+            navigateUp = {},
+            onRouteChange = { _ -> },
+            modifier = Modifier,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SettingsNavHostAppSettingsPreview() {
+    MessagingPreviewTheme {
+        SettingsNavHost(
+            effectiveRoute = SettingsNavRoute.AppSettings,
+            uiState = previewSettingsUiState(),
+            onAction = {},
+            onNavigateBack = {},
+            navigateUp = {},
+            onRouteChange = { _ -> },
+            modifier = Modifier,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SettingsNavHostSubscriptionSettingsPreview() {
+    MessagingPreviewTheme {
+        SettingsNavHost(
+            effectiveRoute = SettingsNavRoute.SubscriptionSettings(
+                subId = 1,
+                title = "SIM 1",
+            ),
+            uiState = previewSettingsUiState(),
+            onAction = {},
+            onNavigateBack = {},
+            navigateUp = {},
+            onRouteChange = { _ -> },
+            modifier = Modifier,
+        )
+    }
+}
+
+private fun previewSettingsUiState(): SettingsUiState {
+    return SettingsUiState(
+        isMultiSim = true,
+        areSubscriptionsLoaded = true,
+        subscriptionSettings = persistentListOf(
+            SubscriptionUiState(
+                subId = 1,
+                displayName = "SIM 1",
+                displayDetail = "+31 6 1234 5678",
+                phoneNumber = "+31 6 1234 5678",
+                defaultPhoneNumber = "+31 6 0000 0000",
+                isGroupMmsSupported = true,
+                isGroupMmsEnabled = true,
+                isDeliveryReportsSupported = true,
+                deliveryReportsEnabled = true,
+                isWirelessAlertsSupported = true,
+                isDefaultSmsApp = true,
+            ),
+            SubscriptionUiState(
+                subId = 2,
+                displayName = "Travel SIM",
+                displayDetail = "+372 5555 0101",
+                isDefaultSmsApp = true,
+            ),
+        ),
+    )
 }

--- a/src/com/android/messaging/ui/appsettings/subscription/ui/SubscriptionSettingsScreen.kt
+++ b/src/com/android/messaging/ui/appsettings/subscription/ui/SubscriptionSettingsScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.appsettings.common.SettingsCategoryHeader
@@ -43,7 +43,7 @@ import com.android.messaging.ui.appsettings.common.SettingsTopAppBar
 import com.android.messaging.ui.appsettings.screen.SettingsScreenModel
 import com.android.messaging.ui.appsettings.screen.model.SettingsAction as Action
 import com.android.messaging.ui.appsettings.subscription.model.SubscriptionUiState
-import com.android.messaging.ui.core.AppTheme
+import com.android.messaging.ui.core.MessagingPreviewTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -80,7 +80,7 @@ internal fun SubscriptionSettingsScreen(
             )
             advancedSettingsItems(
                 subscriptionSettings = subscriptionSettings,
-                onAction = onAction
+                onAction = onAction,
             )
         }
     }
@@ -348,10 +348,36 @@ private fun PhoneNumberDialog(
     )
 }
 
-@Preview
+@PreviewLightDark
+@Composable
+private fun SubscriptionSettingsScreenDefaultSmsPreview() {
+    MessagingPreviewTheme {
+        SubscriptionSettingsScreen(
+            subscriptionSettings = previewSubscriptionSettings(isDefaultSmsApp = true),
+            title = "SIM 1",
+            onAction = {},
+            onNavigateBack = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SubscriptionSettingsScreenNotDefaultSmsPreview() {
+    MessagingPreviewTheme {
+        SubscriptionSettingsScreen(
+            subscriptionSettings = previewSubscriptionSettings(isDefaultSmsApp = false),
+            title = "SIM 2",
+            onAction = {},
+            onNavigateBack = {},
+        )
+    }
+}
+
+@PreviewLightDark
 @Composable
 private fun GroupMmsDialogPreview() {
-    AppTheme {
+    MessagingPreviewTheme {
         GroupMmsDialog(
             isEnabled = true,
             onDismiss = {},
@@ -360,14 +386,44 @@ private fun GroupMmsDialogPreview() {
     }
 }
 
-@Preview
+@PreviewLightDark
+@Composable
+private fun GroupMmsDialogDisabledPreview() {
+    MessagingPreviewTheme {
+        GroupMmsDialog(
+            isEnabled = false,
+            onDismiss = {},
+            onConfirm = {},
+        )
+    }
+}
+
+@PreviewLightDark
 @Composable
 private fun PhoneNumberDialogPreview() {
-    AppTheme {
+    MessagingPreviewTheme {
         PhoneNumberDialog(
             currentNumber = "+31 6 1234 5678",
             onDismiss = {},
             onConfirm = {},
         )
     }
+}
+
+private fun previewSubscriptionSettings(isDefaultSmsApp: Boolean): SubscriptionUiState {
+    return SubscriptionUiState(
+        subId = 1,
+        displayName = "SIM 1",
+        displayDetail = "+31 6 1234 5678",
+        phoneNumber = "+31 6 1234 5678",
+        defaultPhoneNumber = "+31 6 0000 0000",
+        isGroupMmsSupported = true,
+        isGroupMmsEnabled = true,
+        autoRetrieveMms = true,
+        autoRetrieveMmsWhenRoaming = false,
+        isDeliveryReportsSupported = true,
+        deliveryReportsEnabled = true,
+        isWirelessAlertsSupported = true,
+        isDefaultSmsApp = isDefaultSmsApp,
+    )
 }

--- a/src/com/android/messaging/ui/conversation/addparticipants/AddParticipantsScreen.kt
+++ b/src/com/android/messaging/ui/conversation/addparticipants/AddParticipantsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.android.messaging.R
@@ -30,6 +31,8 @@ import com.android.messaging.ui.conversation.addParticipantsContactDestinationRo
 import com.android.messaging.ui.conversation.addParticipantsContactRowTestTag
 import com.android.messaging.ui.conversation.addparticipants.model.AddParticipantsEffect
 import com.android.messaging.ui.conversation.addparticipants.model.AddParticipantsUiState
+import com.android.messaging.ui.conversation.preview.previewRecipientPickerUiState
+import com.android.messaging.ui.conversation.preview.previewSelectedRecipient
 import com.android.messaging.ui.conversation.recipientpicker.component.RecipientSelectionContent
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerListItem
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.SelectedRecipient
@@ -38,7 +41,9 @@ import com.android.messaging.ui.conversation.recipientpicker.model.selection.Rec
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionPrimaryActionUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionRowDecorators
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionStrings
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import com.android.messaging.util.UiUtils
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun AddParticipantsScreen(
@@ -210,5 +215,24 @@ private fun addParticipantsQueryHint(
     return when {
         hasSelectedRecipients -> stringResource(R.string.recipient_selection_query_hint_more)
         else -> stringResource(R.string.new_chat_query_hint)
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun AddParticipantsRecipientSelectionContentPreview() {
+    MessagingPreviewTheme {
+        AddParticipantsRecipientSelectionContent(
+            modifier = Modifier.fillMaxSize(),
+            uiState = AddParticipantsUiState(
+                isLoadingConversationParticipants = false,
+                recipientPickerUiState = previewRecipientPickerUiState(),
+                selectedRecipients = persistentListOf(previewSelectedRecipient()),
+            ),
+            onConfirmClick = {},
+            onLoadMore = {},
+            onQueryChanged = { _ -> },
+            onRecipientClick = { _ -> },
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/attachment/ui/ConversationMediaThumbnail.kt
+++ b/src/com/android/messaging/ui/conversation/attachment/ui/ConversationMediaThumbnail.kt
@@ -6,8 +6,11 @@ import android.net.Uri
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -23,10 +26,13 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import com.android.messaging.util.ContentType
 
 private const val THUMBNAIL_FADE_IN_DURATION_MILLIS = 90
@@ -271,5 +277,28 @@ private fun resolveBitmapFilterQuality(useBitmapLoader: Boolean): FilterQuality 
     return when {
         useBitmapLoader -> FilterQuality.Medium
         else -> FilterQuality.Low
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaThumbnailPreview() {
+    MessagingPreviewColumn {
+        Row(horizontalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            ConversationMediaThumbnail(
+                modifier = Modifier.size(size = 88.dp),
+                contentUri = "content://com.android.messaging.preview/image.jpg",
+                contentType = "image/jpeg",
+                size = IntSize(width = 256, height = 256),
+                useBitmapLoader = true,
+            )
+            ConversationMediaThumbnail(
+                modifier = Modifier.size(size = 88.dp),
+                contentUri = "content://com.android.messaging.preview/video.mp4",
+                contentType = "video/mp4",
+                size = IntSize(width = 256, height = 256),
+                backgroundColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            )
+        }
     }
 }

--- a/src/com/android/messaging/ui/conversation/attachment/ui/ConversationVCardAttachmentCardContent.kt
+++ b/src/com/android/messaging/ui/conversation/attachment/ui/ConversationVCardAttachmentCardContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Person
@@ -22,14 +23,28 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import coil3.compose.AsyncImage
+import com.android.messaging.R
 import com.android.messaging.data.conversation.model.attachment.ConversationVCardAttachmentType
+import com.android.messaging.ui.conversation.preview.previewVCardUiModel
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import com.android.messaging.util.UriUtil
 
 private val VCARD_AVATAR_SIZE = 36.dp
 private val VCARD_AVATAR_ICON_SIZE = 20.dp
+private const val PREVIEW_LOCAL_AVATAR_URI =
+    "android.resource://com.android.messaging/drawable/ic_launcher_foreground"
+private const val PREVIEW_LONG_CONTACT_TITLE =
+    "Alexandria Cassandra Montgomery-Washington from International Partnerships"
+private const val PREVIEW_LONG_CONTACT_SUBTITLE =
+    "mobile +1 415 555 0198, work +1 415 555 0134, alexandria.montgomery-washington@example.com"
+private const val PREVIEW_LONG_LOCATION_TITLE =
+    "Northwest corner entrance near the visitor center and underground parking"
+private const val PREVIEW_LONG_LOCATION_SUBTITLE =
+    "1600 Amphitheatre Parkway, Building 43, Mountain View, California 94043, United States"
 
 @Composable
 internal fun ConversationVCardAttachmentCardContent(
@@ -221,4 +236,162 @@ private fun resolveSubtitleText(
     return subtitleText ?: subtitleTextResId?.let { subtitleResId ->
         stringResource(subtitleResId)
     }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVCardAttachmentCardContentLoadedPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 16.dp)) {
+            PreviewLoadedConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.CONTACT,
+            )
+            PreviewLoadedConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.LOCATION,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVCardAttachmentCardContentContactVisualPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 16.dp)) {
+            PreviewConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.CONTACT,
+                avatarUri = null,
+                titleText = "Ada Lovelace",
+                titleTextResId = null,
+                subtitleText = "+31 6 2222 3333",
+                subtitleTextResId = null,
+            )
+
+            PreviewConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.CONTACT,
+                avatarUri = PREVIEW_LOCAL_AVATAR_URI,
+                titleText = "Marina Silva",
+                titleTextResId = null,
+                subtitleText = "marina@example.com",
+                subtitleTextResId = null,
+            )
+
+            PreviewConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.CONTACT,
+                avatarUri = null,
+                titleText = null,
+                titleTextResId = R.string.notification_vcard,
+                subtitleText = null,
+                subtitleTextResId = R.string.vcard_tap_hint,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVCardAttachmentCardContentTextStatePreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 16.dp)) {
+            PreviewConversationVCardAttachmentCardContent(
+                modifier = Modifier.width(width = 220.dp),
+                type = ConversationVCardAttachmentType.CONTACT,
+                avatarUri = null,
+                titleText = PREVIEW_LONG_CONTACT_TITLE,
+                titleTextResId = null,
+                subtitleText = PREVIEW_LONG_CONTACT_SUBTITLE,
+                subtitleTextResId = null,
+            )
+
+            PreviewConversationVCardAttachmentCardContent(
+                modifier = Modifier.width(width = 220.dp),
+                type = ConversationVCardAttachmentType.LOCATION,
+                avatarUri = null,
+                titleText = PREVIEW_LONG_LOCATION_TITLE,
+                titleTextResId = null,
+                subtitleText = PREVIEW_LONG_LOCATION_SUBTITLE,
+                subtitleTextResId = null,
+            )
+
+            PreviewConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.CONTACT,
+                avatarUri = null,
+                titleText = "Kai",
+                titleTextResId = null,
+                subtitleText = null,
+                subtitleTextResId = null,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVCardAttachmentCardContentMetadataStatePreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 16.dp)) {
+            PreviewConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.CONTACT,
+                avatarUri = null,
+                titleText = null,
+                titleTextResId = R.string.notification_vcard,
+                subtitleText = null,
+                subtitleTextResId = R.string.loading_vcard,
+            )
+
+            PreviewConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.CONTACT,
+                avatarUri = null,
+                titleText = null,
+                titleTextResId = R.string.notification_vcard,
+                subtitleText = null,
+                subtitleTextResId = R.string.failed_loading_vcard,
+            )
+
+            PreviewConversationVCardAttachmentCardContent(
+                type = ConversationVCardAttachmentType.LOCATION,
+                avatarUri = null,
+                titleText = null,
+                titleTextResId = R.string.notification_location,
+                subtitleText = "Shared map pin",
+                subtitleTextResId = null,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreviewLoadedConversationVCardAttachmentCardContent(
+    type: ConversationVCardAttachmentType,
+) {
+    val uiModel = previewVCardUiModel(type = type)
+    PreviewConversationVCardAttachmentCardContent(
+        type = uiModel.type,
+        avatarUri = uiModel.avatarUri,
+        titleText = uiModel.titleText,
+        titleTextResId = uiModel.titleTextResId,
+        subtitleText = uiModel.subtitleText,
+        subtitleTextResId = uiModel.subtitleTextResId,
+    )
+}
+
+@Composable
+private fun PreviewConversationVCardAttachmentCardContent(
+    modifier: Modifier = Modifier,
+    type: ConversationVCardAttachmentType,
+    avatarUri: String?,
+    titleText: String?,
+    titleTextResId: Int?,
+    subtitleText: String?,
+    subtitleTextResId: Int?,
+) {
+    ConversationVCardAttachmentCardContent(
+        modifier = modifier,
+        type = type,
+        avatarUri = avatarUri,
+        titleText = titleText,
+        titleTextResId = titleTextResId,
+        subtitleText = subtitleText,
+        subtitleTextResId = subtitleTextResId,
+    )
 }

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationAttachmentPreview.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationAttachmentPreview.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
@@ -46,7 +47,16 @@ import com.android.messaging.ui.conversation.audio.formatConversationAudioDurati
 import com.android.messaging.ui.conversation.composer.model.ComposerAttachmentUiModel
 import com.android.messaging.ui.conversation.conversationAttachmentPreviewItemTestTag
 import com.android.messaging.ui.conversation.conversationAttachmentPreviewRemoveButtonTestTag
+import com.android.messaging.ui.conversation.preview.previewPendingAttachment
+import com.android.messaging.ui.conversation.preview.previewPendingAudioAttachment
+import com.android.messaging.ui.conversation.preview.previewResolvedAudioAttachment
+import com.android.messaging.ui.conversation.preview.previewResolvedFileAttachment
+import com.android.messaging.ui.conversation.preview.previewResolvedImageAttachment
+import com.android.messaging.ui.conversation.preview.previewResolvedVCardAttachment
+import com.android.messaging.ui.conversation.preview.previewResolvedVideoAttachment
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 private val ATTACHMENT_PREVIEW_CARD_HEIGHT = 88.dp
 private val ATTACHMENT_PREVIEW_CARD_WIDTH = 220.dp
@@ -462,6 +472,27 @@ private fun InlineAudioRemoveAttachmentButton(
                 id = R.plurals.attachment_preview_close_content_description,
                 count = 1,
             ),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationAttachmentPreviewPreview() {
+    MessagingPreviewTheme {
+        ConversationAttachmentPreview(
+            attachments = persistentListOf(
+                previewPendingAttachment(),
+                previewPendingAudioAttachment(),
+                previewResolvedImageAttachment(),
+                previewResolvedVideoAttachment(),
+                previewResolvedAudioAttachment(),
+                previewResolvedFileAttachment(),
+                previewResolvedVCardAttachment(),
+            ),
+            onPendingAttachmentRemove = { _ -> },
+            onResolvedAttachmentClick = { _ -> },
+            onResolvedAttachmentRemove = { _ -> },
         )
     }
 }

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationAudioRecordingBar.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationAudioRecordingBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -43,12 +44,14 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.CONVERSATION_AUDIO_RECORDING_BAR_TEST_TAG
 import com.android.messaging.ui.conversation.CONVERSATION_AUDIO_RECORDING_CANCEL_BUTTON_TEST_TAG
 import com.android.messaging.ui.conversation.CONVERSATION_AUDIO_RECORDING_LOCK_AFFORDANCE_TEST_TAG
 import com.android.messaging.ui.conversation.audio.formatConversationAudioDuration
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private const val AUDIO_RECORDING_COLOR_ANIMATION_THRESHOLD = 0.7f
 
@@ -405,3 +408,26 @@ private data class ConversationAudioRecordingLockAffordanceVisualState(
     val scale: Float,
     val verticalTranslation: Float,
 )
+
+@PreviewLightDark
+@Composable
+private fun ConversationAudioRecordingBarPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 16.dp)) {
+            ConversationAudioRecordingBar(
+                durationMillis = 12_000L,
+                cancelProgress = 0f,
+                isCancellationArmed = false,
+            )
+            ConversationAudioRecordingBar(
+                durationMillis = 65_000L,
+                cancelProgress = 1f,
+                isCancellationArmed = true,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(space = 16.dp)) {
+                ConversationAudioRecordingLockAffordance(lockProgress = 0f)
+                ConversationAudioRecordingLockAffordance(lockProgress = 1f)
+            }
+        }
+    }
+}

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationComposeBar.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationComposeBar.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.domain.conversation.usecase.draft.model.ConversationDraftSendProtocol
@@ -53,10 +54,15 @@ import com.android.messaging.ui.conversation.CONVERSATION_SEND_BUTTON_SHAPE_CIRC
 import com.android.messaging.ui.conversation.CONVERSATION_SEND_BUTTON_TEST_TAG
 import com.android.messaging.ui.conversation.audio.model.ConversationAudioRecordingPhase
 import com.android.messaging.ui.conversation.audio.model.ConversationAudioRecordingUiState
+import com.android.messaging.ui.conversation.composer.model.ConversationComposerUiState
 import com.android.messaging.ui.conversation.composer.model.ConversationSegmentCounterUiState
 import com.android.messaging.ui.conversation.composer.model.ConversationSendActionButtonGestureState
 import com.android.messaging.ui.conversation.composer.model.ConversationSendActionButtonMode
 import com.android.messaging.ui.conversation.conversationShape
+import com.android.messaging.ui.conversation.preview.previewComposerUiState
+import com.android.messaging.ui.conversation.preview.previewRecordingComposer
+import com.android.messaging.ui.core.MessagingPreviewColumn
+import com.android.messaging.ui.core.MessagingPreviewTheme
 
 internal val AUDIO_RECORD_CANCEL_THRESHOLD = 96.dp
 internal val AUDIO_RECORD_LOCK_THRESHOLD = 72.dp
@@ -67,6 +73,18 @@ private const val CONTENT_SWAP_ENTER_SLIDE_OFFSET_DIVISOR = 10
 private const val CONTENT_SWAP_EXIT_FADE_DURATION_MILLIS = 120
 private const val CONTENT_SWAP_EXIT_SLIDE_DURATION_MILLIS = 180
 private const val CONTENT_SWAP_EXIT_SLIDE_OFFSET_DIVISOR = 12
+
+private const val PREVIEW_MULTILINE_MESSAGE_TEXT = "Can you review these before tonight?\n" +
+    "First pass is enough for the meeting.\n" +
+    "I will send the final attachment after dinner."
+private const val PREVIEW_OVERFLOW_MESSAGE_TEXT =
+    "PreviewOverflowTokenWithoutBreaksABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" +
+        "PreviewOverflowTokenWithoutBreaksABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+private const val PREVIEW_MMS_BODY_TEXT =
+    "Photo attached. I am adding the complete notes from the trip, " +
+        "including the hotel confirmation, train times, restaurant address, " +
+        "and a few reminders about what " +
+        "still needs to be booked before everyone arrives tomorrow afternoon."
 
 @Composable
 internal fun ConversationComposeBar(
@@ -649,3 +667,82 @@ private data class ConversationAudioRecordingGestureController(
     val onAudioRecordingLock: () -> Boolean,
     val onAudioRecordingFinish: (Boolean) -> Unit,
 )
+
+@PreviewLightDark
+@Composable
+private fun ConversationComposeBarTextPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewConversationComposeBar(
+                uiState = previewComposerUiState(),
+            )
+            PreviewConversationComposeBar(
+                uiState = previewComposerUiState(messageText = PREVIEW_MULTILINE_MESSAGE_TEXT),
+            )
+            PreviewConversationComposeBar(
+                uiState = previewComposerUiState(messageText = PREVIEW_OVERFLOW_MESSAGE_TEXT),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationComposeBarSubjectPreview() {
+    MessagingPreviewTheme {
+        PreviewConversationComposeBar(
+            uiState = previewComposerUiState(
+                messageText = PREVIEW_MMS_BODY_TEXT,
+                subjectText = "Trip updates",
+            ).copy(sendProtocol = ConversationDraftSendProtocol.MMS),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationComposeBarRecordingPreview() {
+    MessagingPreviewTheme {
+        PreviewConversationComposeBar(
+            uiState = previewRecordingComposer(isLocked = false),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationComposeBarLockedRecordingPreview() {
+    MessagingPreviewTheme {
+        PreviewConversationComposeBar(
+            uiState = previewRecordingComposer(isLocked = true),
+        )
+    }
+}
+
+@Composable
+private fun PreviewConversationComposeBar(uiState: ConversationComposerUiState) {
+    ConversationComposeBar(
+        audioRecording = uiState.audioRecording,
+        messageText = uiState.messageText,
+        subjectText = uiState.subjectText,
+        sendProtocol = uiState.sendProtocol,
+        segmentCounter = uiState.segmentCounter,
+        isMessageFieldEnabled = uiState.isMessageFieldEnabled,
+        isAttachmentActionEnabled = uiState.isAttachmentActionEnabled,
+        isRecordActionEnabled = uiState.isRecordActionEnabled,
+        isSendActionEnabled = uiState.isSendEnabled,
+        shouldShowRecordAction = uiState.shouldShowRecordAction,
+        onContactAttachClick = {},
+        onMediaPickerClick = {},
+        onLockedAudioRecordingStartRequest = {},
+        onMessageTextChange = { _ -> },
+        onAudioRecordingStartRequest = {},
+        onAudioRecordingFinish = {},
+        onAudioRecordingLock = { true },
+        onAudioRecordingCancel = {},
+        onSendClick = {},
+        onSendActionLongClick = {},
+        onSubjectChipClick = {},
+        onSubjectChipClear = {},
+    )
+}

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationComposeMessageField.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationComposeMessageField.kt
@@ -2,6 +2,7 @@ package com.android.messaging.ui.conversation.composer.ui
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -40,6 +41,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
@@ -51,6 +53,7 @@ import com.android.messaging.ui.conversation.CONVERSATION_ATTACHMENT_CONTACT_MEN
 import com.android.messaging.ui.conversation.CONVERSATION_ATTACHMENT_MEDIA_MENU_ITEM_TEST_TAG
 import com.android.messaging.ui.conversation.CONVERSATION_MMS_INDICATOR_TEST_TAG
 import com.android.messaging.ui.conversation.CONVERSATION_TEXT_FIELD_TEST_TAG
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Composable
 internal fun rememberConversationComposeBarPresentation(): ConversationComposeBarPresentation {
@@ -320,3 +323,67 @@ internal data class ConversationComposeBarPresentation(
     val fieldShape: Shape,
     val fieldColors: TextFieldColors,
 )
+
+@PreviewLightDark
+@Composable
+private fun ConversationComposeMessageFieldPreview() {
+    MessagingPreviewColumn {
+        Column {
+            ConversationComposeMessageField(
+                value = "",
+                enabled = true,
+                sendProtocol = ConversationDraftSendProtocol.SMS,
+                isVisuallyHidden = false,
+                messageFieldFocusRequester = null,
+                presentation = rememberConversationComposeBarPresentation(),
+                isAttachmentActionEnabled = true,
+                isAudioRecordActionEnabled = true,
+                onValueChange = { _ -> },
+                onContactAttachClick = {},
+                onMediaPickerClick = {},
+                onAudioAttachClick = {},
+            )
+            ConversationComposeMessageField(
+                value = "Photo attached",
+                enabled = true,
+                sendProtocol = ConversationDraftSendProtocol.MMS,
+                isVisuallyHidden = false,
+                messageFieldFocusRequester = null,
+                presentation = rememberConversationComposeBarPresentation(),
+                isAttachmentActionEnabled = true,
+                isAudioRecordActionEnabled = false,
+                onValueChange = { _ -> },
+                onContactAttachClick = {},
+                onMediaPickerClick = {},
+                onAudioAttachClick = {},
+            )
+            ConversationComposeMessageField(
+                value = "Disabled conversation",
+                enabled = false,
+                sendProtocol = ConversationDraftSendProtocol.SMS,
+                isVisuallyHidden = false,
+                messageFieldFocusRequester = null,
+                presentation = rememberConversationComposeBarPresentation(),
+                isAttachmentActionEnabled = false,
+                isAudioRecordActionEnabled = false,
+                onValueChange = { _ -> },
+                onContactAttachClick = {},
+                onMediaPickerClick = {},
+                onAudioAttachClick = {},
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationComposeAttachmentMenuContentPreview() {
+    MessagingPreviewColumn {
+        ConversationComposeAttachmentMenuContent(
+            isAudioRecordActionEnabled = false,
+            onMediaPickerClick = {},
+            onAudioAttachClick = {},
+            onContactAttachClick = {},
+        )
+    }
+}

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationComposerSection.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationComposerSection.kt
@@ -4,10 +4,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.android.messaging.domain.conversation.usecase.draft.model.ConversationDraftSendProtocol
 import com.android.messaging.ui.conversation.audio.model.ConversationAudioRecordingUiState
 import com.android.messaging.ui.conversation.composer.model.ComposerAttachmentUiModel
 import com.android.messaging.ui.conversation.composer.model.ConversationSegmentCounterUiState
+import com.android.messaging.ui.conversation.preview.previewComposerWithAttachments
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -75,6 +78,43 @@ internal fun ConversationComposerSection(
             onSendActionLongClick = onSendActionLongClick,
             onSubjectChipClick = onSubjectChipClick,
             onSubjectChipClear = onSubjectChipClear,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationComposerSectionPreview() {
+    val uiState = previewComposerWithAttachments()
+    MessagingPreviewTheme {
+        ConversationComposerSection(
+            audioRecording = uiState.audioRecording,
+            attachments = uiState.attachments,
+            messageText = uiState.messageText,
+            subjectText = uiState.subjectText,
+            sendProtocol = uiState.sendProtocol,
+            segmentCounter = uiState.segmentCounter,
+            isMessageFieldEnabled = uiState.isMessageFieldEnabled,
+            isAttachmentActionEnabled = uiState.isAttachmentActionEnabled,
+            isRecordActionEnabled = uiState.isRecordActionEnabled,
+            isSendActionEnabled = uiState.isSendEnabled,
+            shouldShowRecordAction = uiState.shouldShowRecordAction,
+            messageFieldFocusRequester = FocusRequester(),
+            onContactAttachClick = {},
+            onMediaPickerClick = {},
+            onMessageTextChange = { _ -> },
+            onPendingAttachmentRemove = { _ -> },
+            onResolvedAttachmentClick = { _ -> },
+            onResolvedAttachmentRemove = { _ -> },
+            onAudioRecordingStartRequest = {},
+            onLockedAudioRecordingStartRequest = {},
+            onAudioRecordingFinish = {},
+            onAudioRecordingLock = { true },
+            onAudioRecordingCancel = {},
+            onSendClick = {},
+            onSendActionLongClick = {},
+            onSubjectChipClick = {},
+            onSubjectChipClear = {},
         )
     }
 }

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationSendActionButton.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationSendActionButton.kt
@@ -19,7 +19,9 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -45,10 +47,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.composer.model.ConversationSendActionButtonGestureState
 import com.android.messaging.ui.conversation.composer.model.ConversationSendActionButtonMode
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Immutable
 private data class ConversationSendActionButtonVisualState(
@@ -466,5 +470,66 @@ private fun ConversationSendActionPulseCircle(
                 color = MaterialTheme.colorScheme.error,
                 shape = CircleShape,
             ),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationSendActionButtonPreview() {
+    MessagingPreviewColumn {
+        Row(horizontalArrangement = Arrangement.spacedBy(space = 16.dp)) {
+            PreviewConversationSendActionButton(
+                enabled = true,
+                mode = ConversationSendActionButtonMode.Send,
+                isRecordingActive = false,
+                isRecordingLocked = false,
+            )
+            PreviewConversationSendActionButton(
+                enabled = true,
+                mode = ConversationSendActionButtonMode.Record,
+                isRecordingActive = false,
+                isRecordingLocked = false,
+            )
+            PreviewConversationSendActionButton(
+                enabled = true,
+                mode = ConversationSendActionButtonMode.Record,
+                isRecordingActive = true,
+                isRecordingLocked = false,
+            )
+            PreviewConversationSendActionButton(
+                enabled = true,
+                mode = ConversationSendActionButtonMode.Stop,
+                isRecordingActive = true,
+                isRecordingLocked = true,
+            )
+            PreviewConversationSendActionButton(
+                enabled = false,
+                mode = ConversationSendActionButtonMode.Send,
+                isRecordingActive = false,
+                isRecordingLocked = false,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreviewConversationSendActionButton(
+    enabled: Boolean,
+    mode: ConversationSendActionButtonMode,
+    isRecordingActive: Boolean,
+    isRecordingLocked: Boolean,
+) {
+    ConversationSendActionButton(
+        enabled = enabled,
+        mode = mode,
+        isRecordingActive = isRecordingActive,
+        isRecordingLocked = isRecordingLocked,
+        onClick = {},
+        onLockedStopClick = {},
+        onRecordGestureStart = {},
+        onRecordGestureMove = { _ -> },
+        onRecordGestureLock = { true },
+        onRecordGestureFinish = { _ -> },
+        onSendActionLongClick = {},
     )
 }

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationSimAvatar.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationSimAvatar.kt
@@ -1,7 +1,9 @@
 package com.android.messaging.ui.conversation.composer.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -12,9 +14,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.messaging.data.subscription.model.Subscription
+import com.android.messaging.ui.conversation.preview.previewSubscriptions
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 internal val ConversationSimAvatarDefaultSize: Dp = 40.dp
 
@@ -48,5 +53,17 @@ private fun Subscription.resolveAccentColor(): Color {
     return when (color) {
         0 -> MaterialTheme.colorScheme.primary
         else -> Color(color = color)
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationSimAvatarPreview() {
+    MessagingPreviewColumn {
+        Row(horizontalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            previewSubscriptions().forEach { subscription ->
+                ConversationSimAvatar(subscription = subscription)
+            }
+        }
     }
 }

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationSimSelectorSheet.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationSimSelectorSheet.kt
@@ -23,13 +23,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.data.subscription.model.Subscription
 import com.android.messaging.ui.conversation.CONVERSATION_SIM_SELECTOR_SHEET_TEST_TAG
 import com.android.messaging.ui.conversation.composer.model.ConversationSimSelectorUiState
 import com.android.messaging.ui.conversation.conversationSimSelectorItemTestTag
+import com.android.messaging.ui.conversation.preview.previewSimSelectorUiState
 import com.android.messaging.ui.conversation.resolveDisplayName
+import com.android.messaging.ui.core.MessagingPreviewTheme
 
 private val SHEET_VERTICAL_PADDING = 8.dp
 
@@ -145,5 +148,16 @@ private fun ConversationSimSelectorRow(
                 tint = MaterialTheme.colorScheme.primary,
             )
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationSimSelectorSheetContentPreview() {
+    MessagingPreviewTheme {
+        ConversationSimSelectorSheetContent(
+            uiState = previewSimSelectorUiState(),
+            onSimSelected = { _ -> },
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationSubjectChip.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationSubjectChip.kt
@@ -17,12 +17,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.CONVERSATION_SUBJECT_CHIP_CLEAR_BUTTON_TEST_TAG
 import com.android.messaging.ui.conversation.CONVERSATION_SUBJECT_CHIP_TEST_TAG
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private val SUBJECT_CHIP_TEXT_VERTICAL_PADDING = 12.dp
+private const val PREVIEW_LONG_SUBJECT_TEXT =
+    "Upcoming weekend plans, dinner reservation details, parking instructions, and confirmation number"
 
 @Composable
 internal fun ConversationSubjectChip(
@@ -65,5 +69,29 @@ internal fun ConversationSubjectChip(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationSubjectChipPreview() {
+    MessagingPreviewColumn {
+        ConversationSubjectChip(
+            subjectText = "Dinner reservation details",
+            onClick = {},
+            onClear = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationSubjectChipLongTextPreview() {
+    MessagingPreviewColumn {
+        ConversationSubjectChip(
+            subjectText = PREVIEW_LONG_SUBJECT_TEXT,
+            onClick = {},
+            onClear = {},
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/entry/NewChatScreen.kt
+++ b/src/com/android/messaging/ui/conversation/entry/NewChatScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.android.messaging.R
@@ -35,6 +36,9 @@ import com.android.messaging.ui.conversation.entry.model.NewChatEffect
 import com.android.messaging.ui.conversation.entry.model.NewChatUiState
 import com.android.messaging.ui.conversation.newChatContactDestinationRowTestTag
 import com.android.messaging.ui.conversation.newChatContactRowTestTag
+import com.android.messaging.ui.conversation.preview.previewRecipientPickerUiState
+import com.android.messaging.ui.conversation.preview.previewSelectedRecipient
+import com.android.messaging.ui.conversation.preview.previewSimSelectorUiState
 import com.android.messaging.ui.conversation.recipientpicker.component.RecipientSelectionContent
 import com.android.messaging.ui.conversation.recipientpicker.component.simselector.NewChatSimSelectorRow
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerUiState
@@ -45,6 +49,7 @@ import com.android.messaging.ui.conversation.recipientpicker.model.selection.Rec
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionPrimaryActionUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionRowDecorators
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionStrings
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import com.android.messaging.util.UiUtils
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -388,5 +393,31 @@ private fun newChatTitle(
     return when {
         isCreatingGroup -> stringResource(R.string.conversation_new_group)
         else -> stringResource(R.string.start_new_conversation)
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun NewChatScreenContentPreview() {
+    MessagingPreviewTheme {
+        NewChatScreenContent(
+            modifier = Modifier.fillMaxSize(),
+            pickerUiState = previewRecipientPickerUiState(),
+            simSelectorUiState = previewSimSelectorUiState(),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun NewChatScreenContentCreatingGroupPreview() {
+    MessagingPreviewTheme {
+        NewChatScreenContent(
+            modifier = Modifier.fillMaxSize(),
+            isCreatingGroup = true,
+            pickerUiState = previewRecipientPickerUiState(),
+            selectedGroupRecipients = persistentListOf(previewSelectedRecipient()),
+            simSelectorUiState = previewSimSelectorUiState(),
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/entry/NewGroupButton.kt
+++ b/src/com/android/messaging/ui/conversation/entry/NewGroupButton.kt
@@ -32,8 +32,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Composable
 internal fun NewChatRecipientSelectionTopListContent(
@@ -130,4 +132,15 @@ private fun <T> newChatSpatialAnimationSpec(): FiniteAnimationSpec<T> {
         dampingRatio = Spring.DampingRatioNoBouncy,
         stiffness = Spring.StiffnessMediumLow,
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun NewChatRecipientSelectionTopListContentPreview() {
+    MessagingPreviewColumn {
+        NewChatRecipientSelectionTopListContent(
+            isCreatingGroup = false,
+            onCreateGroupClick = {},
+        )
+    }
 }

--- a/src/com/android/messaging/ui/conversation/mediapicker/ConversationMediaPickerSheetScaffold.kt
+++ b/src/com/android/messaging/ui/conversation/mediapicker/ConversationMediaPickerSheetScaffold.kt
@@ -12,13 +12,17 @@ import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.core.MessagingPreviewTheme
 
 private const val CAMERA_PREVIEW_HEIGHT_FRACTION = 2f / 3f
 private val PICKER_GALLERY_SHEET_HEIGHT_REDUCTION = 16.dp
@@ -88,5 +92,38 @@ private fun ConversationPhotoPickerSheetHeader(
         contentAlignment = Alignment.Center,
     ) {
         BottomSheetDefaults.DragHandle()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewLightDark
+@Composable
+private fun ConversationMediaPickerSheetScaffoldPreview() {
+    MessagingPreviewTheme {
+        ConversationMediaPickerSheetScaffold(
+            scaffoldState = rememberBottomSheetScaffoldState(),
+            photoPickerSheetContent = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(color = MaterialTheme.colorScheme.surface),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(text = "Photo picker")
+                }
+            },
+        ) { _ ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = MaterialTheme.colorScheme.scrim),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "Camera preview",
+                    color = Color.White,
+                )
+            }
+        }
     }
 }

--- a/src/com/android/messaging/ui/conversation/mediapicker/component/ConversationMediaPickerShared.kt
+++ b/src/com/android/messaging/ui/conversation/mediapicker/component/ConversationMediaPickerShared.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CameraAlt
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -24,8 +25,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private val PICKER_CONTROL_BUTTON_SIZE = 48.dp
 
@@ -153,5 +156,31 @@ internal fun PickerOverlayIconButton(
             imageVector = imageVector,
             contentDescription = contentDescription,
         )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaPickerSharedPreview() {
+    MessagingPreviewColumn {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            PermissionFallback(
+                icon = {
+                    Icon(
+                        imageVector = Icons.Rounded.CameraAlt,
+                        contentDescription = null,
+                    )
+                },
+                message = "Allow camera access to take photos and videos.",
+                actionLabel = "Allow camera",
+                onActionClick = {},
+            )
+            Spacer(modifier = Modifier.size(size = 12.dp))
+            PickerOverlayIconButton(
+                contentDescription = "Close",
+                imageVector = Icons.Rounded.Close,
+                onClick = {},
+            )
+        }
     }
 }

--- a/src/com/android/messaging/ui/conversation/mediapicker/component/capture/ConversationMediaCaptureControls.kt
+++ b/src/com/android/messaging/ui/conversation/mediapicker/component/capture/ConversationMediaCaptureControls.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.audio.formatConversationAudioDuration
@@ -33,6 +34,7 @@ import com.android.messaging.ui.conversation.mediapicker.camera.ConversationPhot
 import com.android.messaging.ui.conversation.mediapicker.component.PickerOverlayIconButton
 import com.android.messaging.ui.conversation.mediapicker.component.pickerOverlayContainerColor
 import com.android.messaging.ui.conversation.mediapicker.component.pickerOverlayContentColor
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Composable
 internal fun ConversationMediaCaptureTopBar(
@@ -227,5 +229,43 @@ private fun ConversationMediaRecordingTimerPill(
             color = MaterialTheme.colorScheme.onErrorContainer,
             style = MaterialTheme.typography.labelLarge,
         )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaCaptureControlsPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 24.dp)) {
+            ConversationMediaCaptureTopBar(
+                captureMode = ConversationCaptureMode.Photo,
+                hasFlashUnit = true,
+                isPhotoCaptureInProgress = false,
+                isRecording = false,
+                photoFlashMode = ConversationPhotoFlashMode.Auto,
+                onCloseClick = {},
+                onFlashClick = {},
+            )
+            ConversationMediaCaptureControls(
+                captureMode = ConversationCaptureMode.Photo,
+                isPhotoCaptureInProgress = false,
+                isRecording = false,
+                recordingDurationMillis = 0L,
+                onCaptureClick = {},
+                onPhotoModeClick = {},
+                onSwitchCameraClick = {},
+                onVideoModeClick = {},
+            )
+            ConversationMediaCaptureControls(
+                captureMode = ConversationCaptureMode.Video,
+                isPhotoCaptureInProgress = false,
+                isRecording = true,
+                recordingDurationMillis = 24_000L,
+                onCaptureClick = {},
+                onPhotoModeClick = {},
+                onSwitchCameraClick = {},
+                onVideoModeClick = {},
+            )
+        }
     }
 }

--- a/src/com/android/messaging/ui/conversation/mediapicker/component/capture/ConversationMediaCaptureShutterButton.kt
+++ b/src/com/android/messaging/ui/conversation/mediapicker/component/capture/ConversationMediaCaptureShutterButton.kt
@@ -9,8 +9,10 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -23,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.mediapicker.ConversationCaptureMode
@@ -31,6 +34,7 @@ import com.android.messaging.ui.conversation.mediapicker.component.capture.Conve
 import com.android.messaging.ui.conversation.mediapicker.component.capture.ConversationMediaCaptureShutterPhase.VideoRecording
 import com.android.messaging.ui.conversation.mediapicker.component.pickerOverlayContainerColor
 import com.android.messaging.ui.conversation.mediapicker.component.pickerOverlayContentColor
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private val PICKER_SHUTTER_BORDER_WIDTH = 3.dp
 private val PICKER_SHUTTER_OUTER_SIZE = 78.dp
@@ -455,3 +459,36 @@ private data class ConversationMediaCaptureVideoCenterDotVisualState(
     val alpha: Float,
     val scale: Float,
 )
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaCaptureShutterButtonPreview() {
+    MessagingPreviewColumn {
+        Row(horizontalArrangement = Arrangement.spacedBy(space = 16.dp)) {
+            ConversationMediaCaptureShutterButton(
+                captureMode = ConversationCaptureMode.Photo,
+                isPhotoCaptureInProgress = false,
+                isRecording = false,
+                onClick = {},
+            )
+            ConversationMediaCaptureShutterButton(
+                captureMode = ConversationCaptureMode.Photo,
+                isPhotoCaptureInProgress = true,
+                isRecording = false,
+                onClick = {},
+            )
+            ConversationMediaCaptureShutterButton(
+                captureMode = ConversationCaptureMode.Video,
+                isPhotoCaptureInProgress = false,
+                isRecording = false,
+                onClick = {},
+            )
+            ConversationMediaCaptureShutterButton(
+                captureMode = ConversationCaptureMode.Video,
+                isPhotoCaptureInProgress = false,
+                isRecording = true,
+                onClick = {},
+            )
+        }
+    }
+}

--- a/src/com/android/messaging/ui/conversation/mediapicker/component/capture/ConversationMediaPickerCapture.kt
+++ b/src/com/android/messaging/ui/conversation/mediapicker/component/capture/ConversationMediaPickerCapture.kt
@@ -18,11 +18,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.mediapicker.ConversationCaptureMode
 import com.android.messaging.ui.conversation.mediapicker.camera.ConversationPhotoFlashMode
 import com.android.messaging.ui.conversation.mediapicker.component.PermissionFallback
+import com.android.messaging.ui.core.MessagingPreviewTheme
 
 @Composable
 internal fun ConversationMediaCameraPreviewSurface(
@@ -176,5 +178,45 @@ internal fun ConversationMediaCaptureContent(
                 onVideoModeClick = onVideoModeClick,
             )
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaCameraPreviewSurfacePermissionPreview() {
+    MessagingPreviewTheme {
+        ConversationMediaCameraPreviewSurface(
+            modifier = Modifier.fillMaxSize(),
+            cameraPermissionGranted = false,
+            contentPadding = PaddingValues(),
+            surfaceRequest = null,
+            onRequestCameraPermission = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaCaptureContentPreview() {
+    MessagingPreviewTheme {
+        ConversationMediaCaptureContent(
+            modifier = Modifier.fillMaxSize(),
+            audioPermissionGranted = true,
+            captureMode = ConversationCaptureMode.Video,
+            cameraPermissionGranted = true,
+            hasFlashUnit = true,
+            isPhotoCaptureInProgress = false,
+            isRecording = true,
+            photoFlashMode = ConversationPhotoFlashMode.Off,
+            onCloseClick = {},
+            onRequestAudioPermission = {},
+            onPhotoCaptureClick = {},
+            onPhotoModeClick = {},
+            onSwitchCameraClick = {},
+            onToggleFlashClick = {},
+            onVideoCaptureClick = {},
+            onVideoModeClick = {},
+            recordingDurationMillis = 37_000L,
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/mediapicker/component/review/ConversationMediaPickerReview.kt
+++ b/src/com/android/messaging/ui/conversation/mediapicker/component/review/ConversationMediaPickerReview.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -48,8 +49,12 @@ import com.android.messaging.ui.conversation.composer.model.ConversationSendActi
 import com.android.messaging.ui.conversation.composer.ui.ConversationSendActionButton
 import com.android.messaging.ui.conversation.mediapicker.component.PickerOverlayIconButton
 import com.android.messaging.ui.conversation.mediapicker.component.pickerOverlayContentColor
+import com.android.messaging.ui.conversation.preview.previewResolvedImageAttachment
+import com.android.messaging.ui.conversation.preview.previewResolvedVideoAttachment
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 
 private const val PICKER_REVIEW_PAGE_ASPECT_RATIO = 0.8f
@@ -484,6 +489,31 @@ private fun ConversationMediaReviewBottomBar(
             onRecordGestureLock = { false },
             onRecordGestureFinish = {},
             onSendActionLongClick = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaReviewScenePreview() {
+    MessagingPreviewTheme {
+        ConversationMediaReviewScene(
+            modifier = Modifier.fillMaxSize(),
+            attachments = persistentListOf(
+                previewResolvedImageAttachment(),
+                previewResolvedVideoAttachment(),
+            ),
+            conversationTitle = "Ada Lovelace",
+            initiallyReviewedContentUri = null,
+            reviewRequestSequence = 0,
+            isSendActionEnabled = true,
+            onAttachmentPreviewClick = { _ -> },
+            onCaptionChange = { _, _ -> },
+            onAttachmentRemove = { _ -> },
+            onAddMoreClick = {},
+            onClearReview = {},
+            onCloseClick = {},
+            onSendClick = {},
         )
     }
 }

--- a/src/com/android/messaging/ui/conversation/mediapicker/component/review/ConversationMediaReviewBackground.kt
+++ b/src/com/android/messaging/ui/conversation/mediapicker/component/review/ConversationMediaReviewBackground.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -17,11 +18,15 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.IntSize
 import androidx.core.net.toUri
 import com.android.messaging.ui.conversation.attachment.ui.loadConversationMediaThumbnailBitmap
 import com.android.messaging.ui.conversation.composer.model.ComposerAttachmentUiModel
 import com.android.messaging.ui.conversation.mediapicker.component.pickerOverlayContainerColor
+import com.android.messaging.ui.conversation.preview.previewResolvedImageAttachment
+import com.android.messaging.ui.conversation.preview.previewResolvedVideoAttachment
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -212,3 +217,19 @@ private data class ConversationMediaReviewBackgroundState(
     val settledBackgroundImageBitmap: ImageBitmap?,
     val fallbackBackgroundColor: Color,
 )
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaReviewBackgroundPreview() {
+    val attachments = persistentListOf(
+        previewResolvedImageAttachment(),
+        previewResolvedVideoAttachment(),
+    )
+    MessagingPreviewTheme {
+        ConversationMediaReviewBackground(
+            modifier = Modifier.fillMaxSize(),
+            pagerState = rememberPagerState(pageCount = { attachments.size }),
+            attachments = attachments,
+        )
+    }
+}

--- a/src/com/android/messaging/ui/conversation/mediapicker/component/review/ConversationMediaReviewPageCard.kt
+++ b/src/com/android/messaging/ui/conversation/mediapicker/component/review/ConversationMediaReviewPageCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
@@ -32,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -43,8 +45,12 @@ import com.android.messaging.ui.conversation.composer.model.ComposerAttachmentUi
 import com.android.messaging.ui.conversation.mediapicker.component.PickerOverlayBackgroundButton
 import com.android.messaging.ui.conversation.mediapicker.component.pickerOverlayContainerColor
 import com.android.messaging.ui.conversation.mediapicker.component.pickerOverlayContentColor
+import com.android.messaging.ui.conversation.preview.previewResolvedImageAttachment
+import com.android.messaging.ui.conversation.preview.previewResolvedVideoAttachment
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import kotlin.math.absoluteValue
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 
 private const val PICKER_REVIEW_PAGE_REMOVE_ANIMATION_DURATION_MILLIS = 160
@@ -329,3 +335,28 @@ private data class ConversationMediaReviewPageCardContentState(
     val deleteChipVisibilityProgress: Float,
     val removalVisibilityProgress: Float,
 )
+
+@PreviewLightDark
+@Composable
+private fun ConversationMediaReviewPageCardPreview() {
+    val attachments = persistentListOf(
+        previewResolvedImageAttachment(),
+        previewResolvedVideoAttachment(),
+    )
+    val pagerState = rememberPagerState(pageCount = { attachments.size })
+    MessagingPreviewColumn {
+        ConversationMediaReviewPageCard(
+            attachment = attachments.first(),
+            attachments = attachments,
+            page = 0,
+            pageHeight = 240.dp,
+            pageWidth = 192.dp,
+            pagerState = pagerState,
+            previewSize = IntSize(width = 384, height = 480),
+            shouldShowDeleteChip = true,
+            onAttachmentPreviewClick = { _ -> },
+            onAttachmentRemove = { _ -> },
+            onClearReview = {},
+        )
+    }
+}

--- a/src/com/android/messaging/ui/conversation/messages/ui/ConversationMessageSeparator.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/ConversationMessageSeparator.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private val messagesSeparatorSpacing = 12.dp
 private val messagesSeparatorPadding = PaddingValues(
@@ -57,6 +60,142 @@ private fun ConversationDateSeparator(
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(messagesSeparatorPadding),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ColumnWithSeparatorStatePreview() {
+    ConversationMessageSeparatorPreviewColumn {
+        ColumnWithSeparatorPreviewItem(
+            showDateSeparator = true,
+            dateSeparatorText = "Today",
+            contentText = "Visible separator",
+        )
+        ColumnWithSeparatorPreviewItem(
+            showDateSeparator = false,
+            dateSeparatorText = null,
+            contentText = "No separator",
+        )
+        ColumnWithSeparatorPreviewItem(
+            showDateSeparator = false,
+            dateSeparatorText = "Yesterday",
+            contentText = "Date text ignored",
+        )
+        ColumnWithSeparatorPreviewItem(
+            showDateSeparator = true,
+            dateSeparatorText = null,
+            contentText = "Separator requested without text",
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationDateSeparatorTextPreview() {
+    ConversationMessageSeparatorPreviewColumn {
+        ConversationDateSeparator(
+            text = "Today",
+        )
+        ConversationDateSeparator(
+            text = "Mon, May 25",
+        )
+        ConversationDateSeparator(
+            text = "Wednesday, September 30, 2026",
+        )
+        ConversationDateSeparator(
+            text = "Wednesday, September 30, 2026 at 11:59 PM",
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ColumnWithSeparatorContentPreview() {
+    ConversationMessageSeparatorPreviewColumn {
+        ColumnWithSeparator(
+            modifier = Modifier,
+            showDateSeparator = true,
+            dateSeparatorText = "Today",
+        ) {
+            ConversationMessageSeparatorPreviewContent(
+                text = "First message after a day boundary",
+            )
+        }
+        ColumnWithSeparator(
+            modifier = Modifier,
+            showDateSeparator = false,
+            dateSeparatorText = null,
+        ) {
+            ConversationMessageSeparatorPreviewContent(
+                text = "Second message in the same separated group",
+            )
+        }
+        ColumnWithSeparator(
+            modifier = Modifier,
+            showDateSeparator = false,
+            dateSeparatorText = null,
+        ) {
+            ConversationMessageSeparatorPreviewContent(
+                text = "Clustered continuation without extra separator spacing",
+            )
+        }
+        ColumnWithSeparator(
+            modifier = Modifier,
+            showDateSeparator = false,
+            dateSeparatorText = null,
+        ) {
+            ConversationMessageSeparatorPreviewContent(
+                text = "Another continuation row",
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConversationMessageSeparatorPreviewColumn(content: @Composable () -> Unit) {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(space = 12.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ColumnWithSeparatorPreviewItem(
+    showDateSeparator: Boolean,
+    dateSeparatorText: String?,
+    contentText: String,
+) {
+    ColumnWithSeparator(
+        modifier = Modifier,
+        showDateSeparator = showDateSeparator,
+        dateSeparatorText = dateSeparatorText,
+    ) {
+        ConversationMessageSeparatorPreviewContent(
+            text = contentText,
+        )
+    }
+}
+
+@Composable
+private fun ConversationMessageSeparatorPreviewContent(
+    text: String,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+    ) {
+        Text(
+            modifier = Modifier.padding(all = 12.dp),
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
         )
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/ConversationMessages.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/ConversationMessages.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
@@ -32,7 +33,10 @@ import com.android.messaging.ui.conversation.messages.ui.message.ConversationMes
 import com.android.messaging.ui.conversation.messages.ui.message.conversationMessageDisplayEpochDay
 import com.android.messaging.ui.conversation.messages.ui.message.formatDateSeparatorText
 import com.android.messaging.ui.conversation.messages.ui.message.resolveConversationMessageSimDisplayName
+import com.android.messaging.ui.conversation.preview.previewMessages
+import com.android.messaging.ui.conversation.preview.previewSubscriptions
 import com.android.messaging.ui.conversation.resolveDisplayName
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import java.util.TimeZone
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
@@ -494,4 +498,27 @@ private fun shouldShowDateSeparatorBetweenMessages(
     )
 
     return messageAboveEpochDay != currentEpochDay
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessagesPreview() {
+    MessagingPreviewTheme {
+        ConversationMessages(
+            messages = previewMessages(),
+            listState = LazyListState(),
+            selectedMessageIds = persistentSetOf("outgoing-delivered"),
+            showIncomingParticipantIdentity = true,
+            subscriptions = previewSubscriptions(),
+            currentSendSimDisplayName = "Personal",
+            onAttachmentClick = { _, _ -> },
+            onExternalUriClick = {},
+            onMessageClick = {},
+            onMessageAvatarClick = {},
+            onMessageDownloadClick = {},
+            onMessageLongClick = {},
+            onMessageResendClick = {},
+            onSimSelectorClick = {},
+        )
+    }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationGenericInlineAttachmentRow.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationGenericInlineAttachmentRow.kt
@@ -20,8 +20,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.messages.model.attachment.ConversationInlineAttachment
+import com.android.messaging.ui.conversation.preview.previewInlineFileAttachment
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Composable
 internal fun ConversationGenericInlineAttachmentRow(
@@ -114,4 +117,17 @@ private fun ConversationFileInlineAttachmentIcon() {
         imageVector = Icons.Rounded.Description,
         contentDescription = null,
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationGenericInlineAttachmentRowPreview() {
+    MessagingPreviewColumn {
+        ConversationGenericInlineAttachmentRow(
+            attachment = previewInlineFileAttachment(),
+            onAttachmentClick = { _, _ -> },
+            onExternalUriClick = {},
+            onLongClick = {},
+        )
+    }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationInlineAttachmentRow.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationInlineAttachmentRow.kt
@@ -1,7 +1,15 @@
 package com.android.messaging.ui.conversation.messages.ui.attachment
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.messages.model.attachment.ConversationInlineAttachment
+import com.android.messaging.ui.conversation.preview.previewInlineAudioAttachment
+import com.android.messaging.ui.conversation.preview.previewInlineFileAttachment
+import com.android.messaging.ui.conversation.preview.previewInlineVCardAttachment
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Composable
 internal fun ConversationInlineAttachmentRow(
@@ -41,6 +49,29 @@ internal fun ConversationInlineAttachmentRow(
                 onExternalUriClick = onExternalUriClick,
                 onLongClick = onLongClick,
             )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationInlineAttachmentRowPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            listOf(
+                previewInlineAudioAttachment(),
+                previewInlineVCardAttachment(),
+                previewInlineFileAttachment(),
+            ).forEach { attachment ->
+                ConversationInlineAttachmentRow(
+                    attachment = attachment,
+                    isIncoming = true,
+                    isSelectionMode = false,
+                    useStandaloneAudioAttachmentBackground = true,
+                    onAttachmentClick = { _, _ -> },
+                    onExternalUriClick = {},
+                )
+            }
         }
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationInlineAudioAttachmentRow.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationInlineAudioAttachmentRow.kt
@@ -35,11 +35,13 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.CONVERSATION_INLINE_AUDIO_ATTACHMENT_PLAY_BUTTON_TEST_TAG
 import com.android.messaging.ui.conversation.CONVERSATION_INLINE_AUDIO_ATTACHMENT_PROGRESS_TEST_TAG
 import com.android.messaging.ui.conversation.messages.model.attachment.ConversationInlineAttachment
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private val AUDIO_ATTACHMENT_HEIGHT = 70.dp
 
@@ -341,3 +343,54 @@ internal data class ConversationInlineAudioAttachmentColors(
     val progressTrack: Color,
     val secondaryContent: Color,
 )
+
+@PreviewLightDark
+@Composable
+private fun ConversationInlineAudioAttachmentRowContentPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            ConversationInlineAudioAttachmentRowContent(
+                colors = rememberConversationInlineAudioAttachmentColors(
+                    isIncoming = true,
+                    isSelectionMode = false,
+                    useStandaloneAudioAttachmentBackground = true,
+                ),
+                isSelectionMode = false,
+                isPlaying = false,
+                title = "Voice note",
+                durationLabel = "0:42",
+                progress = 0f,
+                onClick = {},
+                onLongClick = {},
+            )
+            ConversationInlineAudioAttachmentRowContent(
+                colors = rememberConversationInlineAudioAttachmentColors(
+                    isIncoming = false,
+                    isSelectionMode = false,
+                    useStandaloneAudioAttachmentBackground = true,
+                ),
+                isSelectionMode = false,
+                isPlaying = true,
+                title = "Recorded message",
+                durationLabel = "1:12",
+                progress = 0.45f,
+                onClick = {},
+                onLongClick = {},
+            )
+            ConversationInlineAudioAttachmentRowContent(
+                colors = rememberConversationInlineAudioAttachmentColors(
+                    isIncoming = true,
+                    isSelectionMode = true,
+                    useStandaloneAudioAttachmentBackground = false,
+                ),
+                isSelectionMode = true,
+                isPlaying = false,
+                title = "Selected audio",
+                durationLabel = "0:09",
+                progress = 0.25f,
+                onClick = {},
+                onLongClick = {},
+            )
+        }
+    }
+}

--- a/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationMessageAttachments.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationMessageAttachments.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.messages.model.attachment.ConversationAttachmentItem
 import com.android.messaging.ui.conversation.messages.model.attachment.ConversationAttachmentSections
+import com.android.messaging.ui.conversation.preview.previewAttachmentSections
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Composable
 internal fun ConversationMessageAttachments(
@@ -69,5 +72,23 @@ internal fun ConversationMessageAttachments(
                 }
             }
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageAttachmentsPreview() {
+    MessagingPreviewColumn {
+        ConversationMessageAttachments(
+            attachmentSections = previewAttachmentSections(),
+            hasTextAboveVisualAttachments = true,
+            hasTextBelowVisualAttachments = true,
+            isIncoming = true,
+            isSelectionMode = false,
+            useStandaloneAudioAttachmentBg = true,
+            onAttachmentClick = { _, _ -> },
+            onExternalUriClick = {},
+            onMessageLongClick = {},
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationVCardInlineAttachmentRow.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationVCardInlineAttachmentRow.kt
@@ -1,6 +1,8 @@
 package com.android.messaging.ui.conversation.messages.ui.attachment
 
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -8,9 +10,23 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.android.messaging.R
+import com.android.messaging.data.conversation.model.attachment.ConversationVCardAttachmentType
 import com.android.messaging.ui.conversation.attachment.ui.ConversationVCardAttachmentCardContent
 import com.android.messaging.ui.conversation.messages.model.attachment.ConversationInlineAttachment
+import com.android.messaging.ui.conversation.preview.previewInlineVCardAttachment
+import com.android.messaging.ui.core.MessagingPreviewColumn
+
+private const val PREVIEW_LONG_CONTACT_TITLE =
+    "Alexandria Cassandra Montgomery-Washington from International Partnerships"
+private const val PREVIEW_LONG_CONTACT_SUBTITLE =
+    "mobile +1 415 555 0198, work +1 415 555 0134, alexandria.montgomery-washington@example.com"
+private const val PREVIEW_LONG_LOCATION_TITLE =
+    "Northwest corner entrance near the visitor center and underground parking"
+private const val PREVIEW_LONG_LOCATION_SUBTITLE =
+    "1600 Amphitheatre Parkway, Building 43, Mountain View, California 94043, United States"
 
 @Composable
 internal fun ConversationVCardInlineAttachmentRow(
@@ -76,4 +92,152 @@ internal fun ConversationVCardInlineAttachmentRowContent(
             subtitleTextResId = attachment.subtitleTextResId,
         )
     }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVCardInlineAttachmentRowLoadedPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment(
+                    type = ConversationVCardAttachmentType.CONTACT,
+                ),
+            )
+
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment(
+                    type = ConversationVCardAttachmentType.LOCATION,
+                ),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVCardInlineAttachmentRowLongTextPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment(
+                    type = ConversationVCardAttachmentType.CONTACT,
+                ).copy(
+                    key = "long-contact",
+                    titleText = PREVIEW_LONG_CONTACT_TITLE,
+                    subtitleText = PREVIEW_LONG_CONTACT_SUBTITLE,
+                ),
+            )
+
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment(
+                    type = ConversationVCardAttachmentType.LOCATION,
+                ).copy(
+                    key = "long-location",
+                    titleText = PREVIEW_LONG_LOCATION_TITLE,
+                    subtitleText = PREVIEW_LONG_LOCATION_SUBTITLE,
+                ),
+            )
+
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment(
+                    type = ConversationVCardAttachmentType.CONTACT,
+                ).copy(
+                    key = "contact-without-subtitle",
+                    titleText = "Kai",
+                    subtitleText = null,
+                    subtitleTextResId = null,
+                ),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVCardInlineAttachmentRowMetadataStatePreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment().copy(
+                    key = "missing-contact",
+                    titleText = null,
+                    titleTextResId = R.string.notification_vcard,
+                    subtitleText = null,
+                    subtitleTextResId = R.string.vcard_tap_hint,
+                ),
+            )
+
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment().copy(
+                    key = "loading-contact",
+                    titleText = null,
+                    titleTextResId = R.string.notification_vcard,
+                    subtitleText = null,
+                    subtitleTextResId = R.string.loading_vcard,
+                ),
+            )
+
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment().copy(
+                    key = "failed-contact",
+                    titleText = null,
+                    titleTextResId = R.string.notification_vcard,
+                    subtitleText = null,
+                    subtitleTextResId = R.string.failed_loading_vcard,
+                ),
+            )
+
+            PreviewConversationVCardInlineAttachmentRow(
+                attachment = previewInlineVCardAttachment(
+                    type = ConversationVCardAttachmentType.LOCATION,
+                ).copy(
+                    key = "location-title-resource",
+                    titleText = null,
+                    titleTextResId = R.string.notification_location,
+                    subtitleText = "Shared map pin",
+                ),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVCardInlineAttachmentRowInteractionStatePreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            ConversationVCardInlineAttachmentRowContent(
+                attachment = previewInlineVCardAttachment().copy(
+                    key = "selection-mode",
+                ),
+                isSelectionMode = true,
+                onClick = {},
+                onLongClick = {},
+            )
+
+            ConversationVCardInlineAttachmentRowContent(
+                attachment = previewInlineVCardAttachment().copy(
+                    key = "without-open-action",
+                    openAction = null,
+                ),
+                isSelectionMode = false,
+                onClick = null,
+                onLongClick = {},
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreviewConversationVCardInlineAttachmentRow(
+    attachment: ConversationInlineAttachment.VCard,
+) {
+    ConversationVCardInlineAttachmentRow(
+        attachment = attachment,
+        isSelectionMode = false,
+        onAttachmentClick = { _, _ -> },
+        onExternalUriClick = {},
+        onLongClick = {},
+    )
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationVisualAttachments.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/attachment/ConversationVisualAttachments.kt
@@ -28,14 +28,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.attachment.ui.ConversationMediaThumbnail
 import com.android.messaging.ui.conversation.messages.model.attachment.ConversationMessageAttachment
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessagePartUiModel
+import com.android.messaging.ui.conversation.preview.previewMessageAttachments
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import com.android.messaging.util.ContentType
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 internal val MESSAGE_ATTACHMENT_CORNER_RADIUS = 0.dp
 internal val MESSAGE_ATTACHMENT_GRID_SPACING = 6.dp
@@ -395,5 +399,38 @@ private fun resolvePartAspectRatio(
         }
 
         else -> MESSAGE_ATTACHMENT_DEFAULT_IMAGE_ASPECT_RATIO
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationVisualAttachmentsPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            ConversationGalleryVisualAttachments(
+                attachments = previewMessageAttachments(),
+                hasTextAboveVisualAttachments = false,
+                hasTextBelowVisualAttachments = true,
+                onAttachmentClick = { _, _ -> },
+                onExternalUriClick = {},
+                onMessageLongClick = {},
+            )
+            ConversationStandaloneVisualAttachment(
+                attachment = previewMessageAttachments().first(),
+                hasTextAboveVisualAttachments = true,
+                hasTextBelowVisualAttachments = false,
+                onAttachmentClick = { _, _ -> },
+                onExternalUriClick = {},
+                onMessageLongClick = {},
+            )
+            ConversationGalleryVisualAttachments(
+                attachments = persistentListOf(previewMessageAttachments().last()),
+                hasTextAboveVisualAttachments = false,
+                hasTextBelowVisualAttachments = false,
+                onAttachmentClick = { _, _ -> },
+                onExternalUriClick = {},
+                onMessageLongClick = {},
+            )
+        }
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessage.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessage.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
@@ -24,6 +25,15 @@ import com.android.messaging.sms.cleanseMmsSubject
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageContent
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel.Status
+import com.android.messaging.ui.conversation.preview.previewAudioPart
+import com.android.messaging.ui.conversation.preview.previewFilePart
+import com.android.messaging.ui.conversation.preview.previewImagePart
+import com.android.messaging.ui.conversation.preview.previewIncomingMessage
+import com.android.messaging.ui.conversation.preview.previewMmsDownloadUiModel
+import com.android.messaging.ui.conversation.preview.previewOutgoingMessage
+import com.android.messaging.ui.conversation.preview.previewVCardPart
+import com.android.messaging.ui.conversation.preview.previewVideoPart
+import kotlinx.collections.immutable.persistentListOf
 
 private const val MESSAGE_BUBBLE_MAX_WIDTH_DP = 360
 private const val MESSAGE_BUBBLE_WIDTH_FRACTION = 0.8f
@@ -417,5 +427,226 @@ private fun messageStatusTextResourceId(status: Status): Int? {
             R.string.message_status_send_failed_emergency_number
         }
         else -> null
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageOutgoingStatusPreview() {
+    ConversationMessagePreviewColumn {
+        outgoingStatusPreviewItems().forEach { item ->
+            ConversationMessagePreviewItem(
+                message = previewOutgoingMessage(
+                    messageId = item.messageId,
+                    text = item.text,
+                    status = item.status,
+                ),
+                simDisplayName = "Personal",
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageIncomingStatusPreview() {
+    ConversationMessagePreviewColumn {
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-complete",
+                text = "Incoming complete message.",
+                status = Status.Incoming.Complete,
+            ),
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-unknown",
+                text = "Incoming message with unknown status.",
+                status = Status.Unknown,
+                protocol = ConversationMessageUiModel.Protocol.UNKNOWN,
+            ),
+            simDisplayName = "Personal",
+        )
+        mmsDownloadStatusPreviewItems().forEach { item ->
+            ConversationMessagePreviewItem(
+                message = previewIncomingMessage(
+                    messageId = item.messageId,
+                    text = null,
+                    parts = persistentListOf(),
+                    status = item.status,
+                    mmsDownload = previewMmsDownloadUiModel(state = item.downloadState),
+                    protocol = ConversationMessageUiModel.Protocol.MMS_PUSH_NOTIFICATION,
+                    canDownloadMessage = item.canDownloadMessage,
+                ),
+                simDisplayName = "Personal",
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageAttachmentContentPreview() {
+    ConversationMessagePreviewColumn {
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-image-only",
+                text = null,
+                parts = persistentListOf(previewImagePart(text = null)),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-image-only-selected",
+                text = null,
+                parts = persistentListOf(previewImagePart(text = null)),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            isSelected = true,
+            isSelectionMode = true,
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-media-with-subject",
+                text = "Long body text below the gallery with a URL " +
+                    "https://example.com/trip-notes.",
+                parts = persistentListOf(
+                    previewImagePart(text = "Image caption"),
+                    previewVideoPart(text = "Video caption"),
+                ),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ).copy(
+                mmsSubject = "Trip media",
+            ),
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "outgoing-audio",
+                text = null,
+                parts = persistentListOf(previewAudioPart(text = "Voice note caption")),
+                status = Status.Outgoing.Delivered,
+            ).copy(
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            simDisplayName = "Work",
+        )
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-vcard",
+                text = null,
+                parts = persistentListOf(previewVCardPart()),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "outgoing-file-unsupported",
+                text = null,
+                parts = persistentListOf(previewFilePart(text = "Unsupported PDF attachment")),
+                status = Status.Outgoing.Complete,
+            ).copy(
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            simDisplayName = "Work",
+        )
+        ConversationMessagePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "outgoing-youtube-preview",
+                text = "Watch this: https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                status = Status.Outgoing.Delivered,
+            ),
+            simDisplayName = "Personal",
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageClusterSelectionPreview() {
+    ConversationMessagePreviewColumn {
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-cluster-start",
+                text = "Incoming cluster starts here.",
+            ).copy(
+                canClusterWithNext = true,
+            ),
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-cluster-middle",
+                text = "Incoming cluster middle.",
+            ).copy(
+                canClusterWithPrevious = true,
+                canClusterWithNext = true,
+            ),
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-cluster-end",
+                text = "Incoming cluster ends here.",
+            ).copy(
+                canClusterWithPrevious = true,
+            ),
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "outgoing-cluster-start",
+                text = "Outgoing cluster starts here.",
+            ).copy(
+                canClusterWithNext = true,
+            ),
+            simDisplayName = "Work",
+        )
+        ConversationMessagePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "outgoing-cluster-end",
+                text = "Outgoing cluster ends here.",
+            ).copy(
+                canClusterWithPrevious = true,
+            ),
+            simDisplayName = "Work",
+        )
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-identity-hidden",
+                text = "Incoming without participant identity.",
+            ),
+            showIncomingParticipantIdentity = false,
+            simDisplayName = null,
+        )
+        ConversationMessagePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "incoming-selection-unselected",
+                text = "Selection mode, not selected.",
+            ),
+            isSelectionMode = true,
+            simDisplayName = "Personal",
+        )
+        ConversationMessagePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "outgoing-selection-selected",
+                text = "Selection mode, selected.",
+                status = Status.Outgoing.Failed,
+            ),
+            isSelected = true,
+            isSelectionMode = true,
+            simDisplayName = "Work",
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageAvatar.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageAvatar.kt
@@ -1,7 +1,9 @@
 package com.android.messaging.ui.conversation.messages.ui.message
 
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -20,10 +22,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.android.messaging.sms.MmsSmsUtils
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
+import com.android.messaging.ui.conversation.preview.previewIncomingMessage
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 internal val CONVERSATION_MESSAGE_AVATAR_SIZE = 32.dp
 internal val CONVERSATION_MESSAGE_AVATAR_GAP = 8.dp
@@ -188,3 +193,25 @@ private data class ConversationMessageAvatarColors(
     val container: Color,
     val content: Color,
 )
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageAvatarPreview() {
+    MessagingPreviewColumn {
+        Row(horizontalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            ConversationMessageAvatar(
+                message = previewIncomingMessage(),
+                onClick = {},
+                onLongClick = {},
+            )
+            ConversationMessageAvatar(
+                message = previewIncomingMessage(
+                    messageId = "phone-avatar",
+                    text = "Phone number sender",
+                ).copy(senderDisplayName = "+31 6 2222 3333"),
+                onClick = {},
+                onLongClick = {},
+            )
+        }
+    }
+}

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageBubble.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageBubble.kt
@@ -20,13 +20,24 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageContent
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel.Status
 import com.android.messaging.ui.conversation.messages.ui.attachment.ConversationMessageAttachments
 import com.android.messaging.ui.conversation.messages.ui.text.ConversationMessageText
 import com.android.messaging.ui.conversation.messages.ui.text.LocalConversationMessageLinkColor
+import com.android.messaging.ui.conversation.preview.previewAudioPart
+import com.android.messaging.ui.conversation.preview.previewFilePart
+import com.android.messaging.ui.conversation.preview.previewImagePart
+import com.android.messaging.ui.conversation.preview.previewIncomingMessage
+import com.android.messaging.ui.conversation.preview.previewMmsDownloadUiModel
+import com.android.messaging.ui.conversation.preview.previewOutgoingMessage
+import com.android.messaging.ui.conversation.preview.previewVCardPart
+import com.android.messaging.ui.conversation.preview.previewVideoPart
+import kotlinx.collections.immutable.persistentListOf
 
 private val MESSAGE_BUBBLE_MEDIA_SECTION_SPACING = 8.dp
 private val MESSAGE_BUBBLE_MEDIA_TEXT_PADDING = 12.dp
@@ -502,5 +513,267 @@ private fun messageSenderColor(
                 isSelected = false,
             )
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageBubbleTextPreview() {
+    ConversationMessageBubblePreviewColumn {
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-short",
+                text = "Incoming text with sender.",
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            simDisplayName = "Personal",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-long",
+                text = PREVIEW_LONG_BUBBLE_TEXT,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            showSender = false,
+            simDisplayName = "Personal",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-link",
+                text = "Outgoing text with link https://example.com/support.",
+                status = Status.Outgoing.Delivered,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            simDisplayName = "Work",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-overflow",
+                text = PREVIEW_OVERFLOW_BUBBLE_TEXT,
+                status = Status.Outgoing.Sending,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            simDisplayName = "Work",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-selected",
+                text = "Selected outgoing text in selection mode.",
+                status = Status.Outgoing.Failed,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            isSelected = true,
+            isSelectionMode = true,
+            simDisplayName = "Work",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-selection-mode",
+                text = "Incoming text while selection mode is active.",
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            isSelectionMode = true,
+            simDisplayName = "Personal",
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageBubbleMmsDownloadPreview() {
+    ConversationMessageBubblePreviewColumn {
+        conversationMessageBubbleMmsDownloadPreviewItems().forEach { item ->
+            ConversationMessageBubblePreviewItem(
+                message = previewIncomingMessage(
+                    messageId = item.messageId,
+                    text = null,
+                    parts = persistentListOf(),
+                    status = item.status,
+                    mmsDownload = previewMmsDownloadUiModel(state = item.downloadState),
+                    protocol = ConversationMessageUiModel.Protocol.MMS_PUSH_NOTIFICATION,
+                    canDownloadMessage = item.canDownloadMessage,
+                ),
+                bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+                isSelected = item.isSelected,
+                simDisplayName = "Personal",
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageBubbleAttachmentSurfacePreview() {
+    ConversationMessageBubblePreviewColumn {
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-media-subject",
+                text = "Body text below the media with https://example.com/trip.",
+                parts = persistentListOf(
+                    previewImagePart(text = "Image caption"),
+                    previewVideoPart(text = "Video caption"),
+                ),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ).copy(
+                mmsSubject = "Trip media",
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.AttachmentsInSurface,
+            simDisplayName = "Personal",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-audio",
+                text = null,
+                parts = persistentListOf(previewAudioPart(text = "Voice note caption")),
+                status = Status.Outgoing.Delivered,
+            ).copy(
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.AttachmentsInSurface,
+            simDisplayName = "Work",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-vcard",
+                text = null,
+                parts = persistentListOf(previewVCardPart()),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.AttachmentsInSurface,
+            simDisplayName = "Personal",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-file",
+                text = null,
+                parts = persistentListOf(previewFilePart(text = "Unsupported PDF attachment")),
+                status = Status.Outgoing.Failed,
+            ).copy(
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.AttachmentsInSurface,
+            isSelected = true,
+            isSelectionMode = true,
+            simDisplayName = "Work",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-youtube",
+                text = "Watch this: https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                status = Status.Outgoing.Delivered,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.AttachmentsInSurface,
+            simDisplayName = "Personal",
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageBubbleAttachmentOnlyPreview() {
+    ConversationMessageBubblePreviewColumn {
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-image-only",
+                text = null,
+                parts = persistentListOf(previewImagePart(text = null)),
+                status = Status.Outgoing.Complete,
+            ).copy(
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.AttachmentOnlyWithoutSurface,
+            simDisplayName = "Work",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-image-only",
+                text = null,
+                parts = persistentListOf(previewImagePart(text = null)),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.AttachmentOnlyWithoutSurface,
+            showSender = false,
+            simDisplayName = "Personal",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-video-only-selected",
+                text = null,
+                parts = persistentListOf(previewVideoPart(text = null)),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.AttachmentOnlyWithoutSurface,
+            isSelected = true,
+            isSelectionMode = true,
+            showSender = false,
+            simDisplayName = "Personal",
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageBubbleClusterShapePreview() {
+    ConversationMessageBubblePreviewColumn {
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-cluster-start",
+                text = "Incoming cluster start.",
+            ).copy(
+                canClusterWithNext = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            simDisplayName = "Personal",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-cluster-middle",
+                text = "Incoming cluster middle.",
+            ).copy(
+                canClusterWithPrevious = true,
+                canClusterWithNext = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            showSender = false,
+            simDisplayName = "Personal",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewIncomingMessage(
+                messageId = "bubble-incoming-cluster-end",
+                text = "Incoming cluster end.",
+            ).copy(
+                canClusterWithPrevious = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            showSender = false,
+            simDisplayName = "Personal",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-cluster-start",
+                text = "Outgoing cluster start.",
+            ).copy(
+                canClusterWithNext = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            simDisplayName = "Work",
+        )
+        ConversationMessageBubblePreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "bubble-outgoing-cluster-end",
+                text = "Outgoing cluster end.",
+            ).copy(
+                canClusterWithPrevious = true,
+            ),
+            bubbleLayoutMode = ConversationMessageBubbleLayoutMode.TextInSurface,
+            simDisplayName = "Work",
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageBubblePreviewSupport.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageBubblePreviewSupport.kt
@@ -1,0 +1,168 @@
+package com.android.messaging.ui.conversation.messages.ui.message
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel.Status
+import com.android.messaging.ui.conversation.messages.model.message.MmsDownloadUiModel
+import com.android.messaging.ui.core.MessagingPreviewColumn
+
+private val PREVIEW_BUBBLE_CONNECTED_CORNER_RADIUS = 6.dp
+private val PREVIEW_BUBBLE_CORNER_RADIUS = 24.dp
+
+internal const val PREVIEW_LONG_BUBBLE_TEXT = "This longer message wraps across several lines " +
+    "inside the bubble so typography, line height, and horizontal padding are visible in the " +
+    "preview. It also includes https://example.com/details for link styling."
+internal const val PREVIEW_OVERFLOW_BUBBLE_TEXT =
+    "SupercalifragilisticexpialidociousPreviewTokenWithoutNaturalBreaks1234567890"
+
+internal data class BubbleMmsDownloadPreviewItem(
+    val messageId: String,
+    val status: Status.Incoming,
+    val downloadState: MmsDownloadUiModel.State,
+    val canDownloadMessage: Boolean,
+    val isSelected: Boolean = false,
+)
+
+@Composable
+internal fun ConversationMessageBubblePreviewColumn(content: @Composable () -> Unit) {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.padding(vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(space = 12.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+internal fun ConversationMessageBubblePreviewItem(
+    message: ConversationMessageUiModel,
+    bubbleLayoutMode: ConversationMessageBubbleLayoutMode,
+    isSelected: Boolean = false,
+    isSelectionMode: Boolean = false,
+    showSender: Boolean = message.isIncoming && !message.canClusterWithPrevious,
+    simDisplayName: String? = null,
+) {
+    ConversationMessageBubble(
+        message = message,
+        isSelected = isSelected,
+        isSelectionMode = isSelectionMode,
+        layout = previewConversationMessageLayout(
+            message = message,
+            bubbleLayoutMode = bubbleLayoutMode,
+            showSender = showSender,
+        ),
+        maxBubbleWidth = 320.dp,
+        simDisplayName = simDisplayName,
+        onAttachmentClick = { _, _ -> },
+        onExternalUriClick = {},
+        onMessageLongClick = {},
+    )
+}
+
+internal fun conversationMessageBubbleMmsDownloadPreviewItems():
+    List<BubbleMmsDownloadPreviewItem> {
+    return listOf(
+        BubbleMmsDownloadPreviewItem(
+            messageId = "bubble-mms-awaiting",
+            status = Status.Incoming.YetToManualDownload,
+            downloadState = MmsDownloadUiModel.State.AwaitingManualDownload,
+            canDownloadMessage = true,
+        ),
+        BubbleMmsDownloadPreviewItem(
+            messageId = "bubble-mms-awaiting-disabled",
+            status = Status.Incoming.YetToManualDownload,
+            downloadState = MmsDownloadUiModel.State.AwaitingManualDownload,
+            canDownloadMessage = false,
+        ),
+        BubbleMmsDownloadPreviewItem(
+            messageId = "bubble-mms-downloading",
+            status = Status.Incoming.ManualDownloading,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+            isSelected = true,
+        ),
+        BubbleMmsDownloadPreviewItem(
+            messageId = "bubble-mms-failed",
+            status = Status.Incoming.DownloadFailed,
+            downloadState = MmsDownloadUiModel.State.DownloadFailed,
+            canDownloadMessage = true,
+        ),
+        BubbleMmsDownloadPreviewItem(
+            messageId = "bubble-mms-failed-disabled",
+            status = Status.Incoming.DownloadFailed,
+            downloadState = MmsDownloadUiModel.State.DownloadFailed,
+            canDownloadMessage = false,
+        ),
+        BubbleMmsDownloadPreviewItem(
+            messageId = "bubble-mms-expired",
+            status = Status.Incoming.ExpiredOrNotAvailable,
+            downloadState = MmsDownloadUiModel.State.ExpiredOrUnavailable,
+            canDownloadMessage = false,
+        ),
+    )
+}
+
+internal fun previewConversationMessageLayout(
+    message: ConversationMessageUiModel,
+    bubbleLayoutMode: ConversationMessageBubbleLayoutMode,
+    showSender: Boolean,
+): ConversationMessageLayout {
+    return ConversationMessageLayout(
+        bubbleShape = previewConversationMessageBubbleShape(message = message),
+        bubbleLayoutMode = bubbleLayoutMode,
+        content = buildConversationMessageContent(
+            message = message,
+            subjectText = message.mmsSubject,
+        ),
+        metadataText = "18:04",
+        showSender = showSender,
+        showAvatarGutter = message.isIncoming,
+        showAvatar = message.isIncoming && !message.canClusterWithNext,
+    )
+}
+
+private fun previewConversationMessageBubbleShape(
+    message: ConversationMessageUiModel,
+): RoundedCornerShape {
+    val topStartCornerRadius = previewClusteredCornerRadius(
+        clustersWithAdjacent = message.canClusterWithPrevious,
+    )
+    val topEndCornerRadius = previewClusteredCornerRadius(
+        clustersWithAdjacent = message.canClusterWithPrevious,
+        useFreeSide = true,
+    )
+    val bottomStartCornerRadius = previewClusteredCornerRadius(
+        clustersWithAdjacent = message.canClusterWithNext,
+    )
+    val bottomEndCornerRadius = previewClusteredCornerRadius(
+        clustersWithAdjacent = message.canClusterWithNext,
+        useFreeSide = true,
+    )
+
+    return RoundedCornerShape(
+        topStart = if (message.isIncoming) topStartCornerRadius else topEndCornerRadius,
+        topEnd = if (message.isIncoming) topEndCornerRadius else topStartCornerRadius,
+        bottomStart = if (message.isIncoming) bottomStartCornerRadius else bottomEndCornerRadius,
+        bottomEnd = if (message.isIncoming) bottomEndCornerRadius else bottomStartCornerRadius,
+    )
+}
+
+private fun previewClusteredCornerRadius(
+    clustersWithAdjacent: Boolean,
+    useFreeSide: Boolean = false,
+): Dp {
+    return when {
+        !clustersWithAdjacent -> PREVIEW_BUBBLE_CORNER_RADIUS
+        useFreeSide -> PREVIEW_BUBBLE_CORNER_RADIUS
+        else -> PREVIEW_BUBBLE_CONNECTED_CORNER_RADIUS
+    }
+}

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageMetadata.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageMetadata.kt
@@ -1,5 +1,7 @@
 package com.android.messaging.ui.conversation.messages.ui.message
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -11,11 +13,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel.Status
 import com.android.messaging.ui.conversation.messages.ui.buildConversationSimLinkAnnotatedString
+import com.android.messaging.ui.conversation.preview.previewIncomingMessage
+import com.android.messaging.ui.conversation.preview.previewOutgoingMessage
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private const val METADATA_SEPARATOR = " • "
 
@@ -107,5 +113,26 @@ private fun messageMetadataColor(
         -> MaterialTheme.colorScheme.error
 
         else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageMetadataPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 8.dp)) {
+            ConversationMessageMetadata(
+                message = previewIncomingMessage(),
+                metadataText = "18:04",
+                simDisplayName = "Personal",
+                onSimSelectorClick = {},
+            )
+            ConversationMessageMetadata(
+                message = previewOutgoingMessage(status = Status.Outgoing.Failed),
+                metadataText = "18:05 • Failed",
+                simDisplayName = "Work",
+                onSimSelectorClick = {},
+            )
+        }
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessagePreviewSupport.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessagePreviewSupport.kt
@@ -1,0 +1,168 @@
+package com.android.messaging.ui.conversation.messages.ui.message
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel.Status
+import com.android.messaging.ui.conversation.messages.model.message.MmsDownloadUiModel
+import com.android.messaging.ui.core.MessagingPreviewColumn
+
+internal data class MessageStatusPreviewItem(
+    val messageId: String,
+    val text: String,
+    val status: Status,
+)
+
+internal data class MessageMmsDownloadPreviewItem(
+    val messageId: String,
+    val status: Status.Incoming,
+    val downloadState: MmsDownloadUiModel.State,
+    val canDownloadMessage: Boolean,
+)
+
+@Composable
+internal fun ConversationMessagePreviewColumn(content: @Composable () -> Unit) {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(space = 12.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+internal fun ConversationMessagePreviewItem(
+    message: ConversationMessageUiModel,
+    isSelected: Boolean = false,
+    isSelectionMode: Boolean = false,
+    showIncomingParticipantIdentity: Boolean = true,
+    simDisplayName: String? = null,
+) {
+    ConversationMessage(
+        message = message,
+        isSelected = isSelected,
+        isSelectionMode = isSelectionMode,
+        showIncomingParticipantIdentity = showIncomingParticipantIdentity,
+        simDisplayName = simDisplayName,
+    )
+}
+
+internal fun outgoingStatusPreviewItems(): List<MessageStatusPreviewItem> {
+    return listOf(
+        MessageStatusPreviewItem(
+            messageId = "outgoing-complete",
+            text = "Outgoing complete message.",
+            status = Status.Outgoing.Complete,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-delivered",
+            text = "Outgoing delivered message.",
+            status = Status.Outgoing.Delivered,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-draft",
+            text = "Outgoing draft message.",
+            status = Status.Outgoing.Draft,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-yet-to-send",
+            text = "Outgoing queued message.",
+            status = Status.Outgoing.YetToSend,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-sending",
+            text = "Outgoing sending message.",
+            status = Status.Outgoing.Sending,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-resending",
+            text = "Outgoing retrying send.",
+            status = Status.Outgoing.Resending,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-awaiting-retry",
+            text = "Outgoing awaiting retry.",
+            status = Status.Outgoing.AwaitingRetry,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-failed",
+            text = "Outgoing failed and can be resent.",
+            status = Status.Outgoing.Failed,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-failed-emergency",
+            text = "Outgoing failed emergency-number message.",
+            status = Status.Outgoing.FailedEmergencyNumber,
+        ),
+        MessageStatusPreviewItem(
+            messageId = "outgoing-unknown",
+            text = "Outgoing message with unknown status.",
+            status = Status.Unknown,
+        ),
+    )
+}
+
+internal fun mmsDownloadStatusPreviewItems(): List<MessageMmsDownloadPreviewItem> {
+    return listOf(
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-yet-to-manual-download",
+            status = Status.Incoming.YetToManualDownload,
+            downloadState = MmsDownloadUiModel.State.AwaitingManualDownload,
+            canDownloadMessage = true,
+        ),
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-yet-to-manual-download-disabled",
+            status = Status.Incoming.YetToManualDownload,
+            downloadState = MmsDownloadUiModel.State.AwaitingManualDownload,
+            canDownloadMessage = false,
+        ),
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-retrying-manual-download",
+            status = Status.Incoming.RetryingManualDownload,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+        ),
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-manual-downloading",
+            status = Status.Incoming.ManualDownloading,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+        ),
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-retrying-auto-download",
+            status = Status.Incoming.RetryingAutoDownload,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+        ),
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-auto-downloading",
+            status = Status.Incoming.AutoDownloading,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+        ),
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-download-failed",
+            status = Status.Incoming.DownloadFailed,
+            downloadState = MmsDownloadUiModel.State.DownloadFailed,
+            canDownloadMessage = true,
+        ),
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-download-failed-disabled",
+            status = Status.Incoming.DownloadFailed,
+            downloadState = MmsDownloadUiModel.State.DownloadFailed,
+            canDownloadMessage = false,
+        ),
+        MessageMmsDownloadPreviewItem(
+            messageId = "incoming-expired",
+            status = Status.Incoming.ExpiredOrNotAvailable,
+            downloadState = MmsDownloadUiModel.State.ExpiredOrUnavailable,
+            canDownloadMessage = false,
+        ),
+    )
+}

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageRows.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageRows.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
@@ -20,8 +21,21 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel.Status
+import com.android.messaging.ui.conversation.preview.previewAudioPart
+import com.android.messaging.ui.conversation.preview.previewFilePart
+import com.android.messaging.ui.conversation.preview.previewImagePart
+import com.android.messaging.ui.conversation.preview.previewIncomingMessage
+import com.android.messaging.ui.conversation.preview.previewMmsDownloadUiModel
+import com.android.messaging.ui.conversation.preview.previewOutgoingMessage
+import com.android.messaging.ui.conversation.preview.previewVCardPart
+import com.android.messaging.ui.conversation.preview.previewVideoPart
+import com.android.messaging.ui.core.MessagingPreviewColumn
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ConversationMessageBubbleRow(
@@ -305,4 +319,375 @@ private fun ConversationMessageAvatarMetadataOffset(
         modifier = Modifier
             .width(width = CONVERSATION_MESSAGE_AVATAR_GUTTER_WIDTH),
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageRowsOutgoingStatusPreview() {
+    ConversationMessageRowsPreviewColumn {
+        conversationMessageRowsOutgoingStatusPreviewItems().forEach { item ->
+            ConversationMessageRowsPreviewItem(
+                message = previewOutgoingMessage(
+                    messageId = item.messageId,
+                    text = item.text,
+                    status = item.status,
+                ),
+                simDisplayName = "Work",
+                metadataText = item.metadataText,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageRowsIncomingStatusPreview() {
+    ConversationMessageRowsPreviewColumn {
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-incoming-complete",
+                text = "Incoming complete row with avatar, sender, and timestamp.",
+                status = Status.Incoming.Complete,
+            ),
+            simDisplayName = "Personal",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-incoming-unknown",
+                text = "Incoming row with unknown protocol and status.",
+                status = Status.Unknown,
+                protocol = ConversationMessageUiModel.Protocol.UNKNOWN,
+            ),
+            simDisplayName = null,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageRowsDirectionMetadataPreview() {
+    ConversationMessageRowsPreviewColumn {
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-incoming",
+                text = PREVIEW_ROWS_LONG_TEXT,
+            ),
+            simDisplayName = "Personal",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-outgoing-delivered",
+                text = "Delivered outgoing row with right alignment and SIM metadata.",
+                status = Status.Outgoing.Delivered,
+            ),
+            simDisplayName = "Work",
+            metadataText = "18:05 \u2022 Delivered",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-outgoing-failed",
+                text = "Failed row shows retry interaction on the bubble and error metadata.",
+                status = Status.Outgoing.Failed,
+            ),
+            simDisplayName = "Personal",
+            metadataText = "18:06 \u2022 Failed",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-hidden-identity",
+                text = "Incoming row with participant identity hidden keeps the bubble flush left.",
+            ),
+            showIncomingParticipantIdentity = false,
+            simDisplayName = null,
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-overflow",
+                text = PREVIEW_ROWS_OVERFLOW_TEXT,
+                status = Status.Outgoing.Complete,
+            ),
+            simDisplayName = null,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageRowsSelectionPreview() {
+    ConversationMessageRowsPreviewColumn {
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-selection-incoming-unselected",
+                text = "Selection mode, incoming row, not selected.",
+            ),
+            isSelected = false,
+            isSelectionMode = true,
+            simDisplayName = "Personal",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-selection-incoming-selected",
+                text = "Selection mode, incoming row, selected.",
+            ),
+            isSelected = true,
+            isSelectionMode = true,
+            simDisplayName = "Personal",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-selection-outgoing-unselected",
+                text = "Selection mode, outgoing row, not selected.",
+                status = Status.Outgoing.Sending,
+            ),
+            isSelected = false,
+            isSelectionMode = true,
+            simDisplayName = "Work",
+            metadataText = "18:07 \u2022 Sending",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-selection-outgoing-selected",
+                text = "Selected outgoing failed row keeps retry state visible " +
+                    "inside selection mode.",
+                status = Status.Outgoing.Failed,
+            ),
+            isSelected = true,
+            isSelectionMode = true,
+            simDisplayName = "Work",
+            metadataText = "18:08 \u2022 Failed",
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageRowsMmsDownloadPreview() {
+    ConversationMessageRowsPreviewColumn {
+        conversationMessageRowsMmsDownloadPreviewItems().forEach { item ->
+            ConversationMessageRowsPreviewItem(
+                message = previewIncomingMessage(
+                    messageId = item.messageId,
+                    text = null,
+                    status = item.status,
+                    parts = persistentListOf(),
+                    mmsDownload = previewMmsDownloadUiModel(state = item.downloadState),
+                    protocol = ConversationMessageUiModel.Protocol.MMS_PUSH_NOTIFICATION,
+                    canDownloadMessage = item.canDownloadMessage,
+                ),
+                isSelected = item.isSelected,
+                isSelectionMode = item.isSelectionMode,
+                simDisplayName = null,
+                metadataText = null,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageRowsAttachmentPreview() {
+    ConversationMessageRowsPreviewColumn {
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-attachments-incoming-gallery",
+                text = "Photo and video from the site visit.",
+                parts = persistentListOf(
+                    previewImagePart(text = "North entrance"),
+                    previewVideoPart(text = "Walkthrough clip"),
+                ),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ).copy(
+                mmsSubject = "Site visit",
+            ),
+            simDisplayName = "Personal",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-attachments-outgoing-audio",
+                text = "Voice memo attached.",
+                parts = persistentListOf(previewAudioPart(text = "Two minute update")),
+                status = Status.Outgoing.Complete,
+            ).copy(
+                mmsSubject = "Audio update",
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+            ),
+            simDisplayName = "Work",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-attachments-vcard",
+                text = null,
+                parts = persistentListOf(previewVCardPart()),
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+                canSaveAttachments = true,
+            ),
+            simDisplayName = null,
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-attachments-image-only",
+                text = null,
+                parts = persistentListOf(previewImagePart(text = null)),
+                status = Status.Outgoing.Complete,
+            ).copy(
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+            ),
+            simDisplayName = "Personal",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-attachments-file-failed",
+                text = "Document did not send.",
+                parts = persistentListOf(previewFilePart(text = "Quarterly report.pdf")),
+                status = Status.Outgoing.Failed,
+            ).copy(
+                protocol = ConversationMessageUiModel.Protocol.MMS,
+            ),
+            isSelected = true,
+            isSelectionMode = true,
+            simDisplayName = "Work",
+            metadataText = "18:11 \u2022 Failed",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-attachments-youtube-preview",
+                text = "Reference clip: https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                status = Status.Outgoing.Delivered,
+            ),
+            simDisplayName = "Personal",
+            metadataText = "18:12 \u2022 Delivered",
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageRowsClusterPreview() {
+    ConversationMessageRowsPreviewColumn {
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-incoming-cluster-start",
+                text = "Cluster start shows sender but no avatar.",
+            ).copy(
+                canClusterWithNext = true,
+            ),
+            simDisplayName = null,
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-incoming-cluster-middle",
+                text = "Cluster middle suppresses sender, avatar, and metadata.",
+            ).copy(
+                canClusterWithPrevious = true,
+                canClusterWithNext = true,
+            ),
+            simDisplayName = null,
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewIncomingMessage(
+                messageId = "rows-incoming-cluster-end",
+                text = "Cluster end restores the avatar and timestamp.",
+            ).copy(
+                canClusterWithPrevious = true,
+            ),
+            simDisplayName = null,
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-outgoing-cluster-start",
+                text = "Outgoing cluster start hides metadata until the last grouped message.",
+            ).copy(
+                canClusterWithNext = true,
+            ),
+            simDisplayName = "Work",
+        )
+
+        ConversationMessageRowsPreviewItem(
+            message = previewOutgoingMessage(
+                messageId = "rows-outgoing-cluster-end",
+                text = "Outgoing cluster end shows right aligned metadata.",
+                status = Status.Outgoing.Delivered,
+            ).copy(
+                canClusterWithPrevious = true,
+            ),
+            simDisplayName = "Work",
+            metadataText = "18:16 \u2022 Delivered",
+        )
+    }
+}
+
+@Composable
+private fun ConversationMessageRowsPreviewColumn(content: @Composable () -> Unit) {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.padding(vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(space = 12.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ConversationMessageRowsPreviewItem(
+    message: ConversationMessageUiModel,
+    isSelected: Boolean = false,
+    isSelectionMode: Boolean = false,
+    showIncomingParticipantIdentity: Boolean = true,
+    simDisplayName: String? = null,
+    metadataText: String? = "18:04",
+) {
+    val layout = previewConversationMessageRowsLayout(
+        message = message,
+        showIncomingParticipantIdentity = showIncomingParticipantIdentity,
+        metadataText = metadataText,
+    )
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = conversationMessageRowsPreviewHorizontalAlignment(
+            message = message,
+        ),
+    ) {
+        ConversationMessageBubbleRow(
+            message = message,
+            isSelected = isSelected,
+            isSelectionMode = isSelectionMode,
+            layout = layout,
+            maxBubbleWidth = 320.dp,
+            simDisplayName = simDisplayName,
+            onAttachmentClick = { _, _ -> },
+            onExternalUriClick = {},
+            onMessageClick = {},
+            onMessageAvatarClick = {},
+            onMessageDownloadClick = {},
+            onMessageLongClick = {},
+            onMessageResendClick = {},
+        )
+        ConversationMessageMetadataRow(
+            message = message,
+            isSelectionMode = isSelectionMode,
+            layout = layout,
+            maxBubbleWidth = 320.dp,
+            simDisplayName = simDisplayName,
+            onSimSelectorClick = {},
+        )
+    }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageRowsPreviewSupport.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageRowsPreviewSupport.kt
@@ -1,0 +1,276 @@
+package com.android.messaging.ui.conversation.messages.ui.message
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageContent
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel.Status
+import com.android.messaging.ui.conversation.messages.model.message.MmsDownloadUiModel
+
+private val PREVIEW_ROWS_BUBBLE_CONNECTED_CORNER_RADIUS = 6.dp
+private val PREVIEW_ROWS_BUBBLE_CORNER_RADIUS = 24.dp
+
+internal const val PREVIEW_ROWS_LONG_TEXT =
+    "This row preview uses a longer body so the row has to preserve alignment, " +
+        "bubble width, metadata placement, and avatar spacing while the content wraps " +
+        "across several lines inside the message bubble."
+
+internal const val PREVIEW_ROWS_OVERFLOW_TEXT =
+    "SupercalifragilisticexpialidociousRowsPreviewTokenWithoutNaturalBreaks1234567890"
+
+internal data class RowsStatusPreviewItem(
+    val messageId: String,
+    val text: String,
+    val status: Status,
+    val metadataText: String?,
+)
+
+internal data class RowsMmsDownloadPreviewItem(
+    val messageId: String,
+    val status: Status.Incoming,
+    val downloadState: MmsDownloadUiModel.State,
+    val canDownloadMessage: Boolean,
+    val isSelected: Boolean = false,
+    val isSelectionMode: Boolean = false,
+)
+
+@Suppress("LongMethod")
+internal fun conversationMessageRowsOutgoingStatusPreviewItems(): List<RowsStatusPreviewItem> {
+    return listOf(
+        RowsStatusPreviewItem(
+            messageId = "rows-status-complete",
+            text = "Complete outgoing row.",
+            status = Status.Outgoing.Complete,
+            metadataText = "18:01",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-delivered",
+            text = "Delivered outgoing row.",
+            status = Status.Outgoing.Delivered,
+            metadataText = "18:02 \u2022 Delivered",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-draft",
+            text = "Draft outgoing row.",
+            status = Status.Outgoing.Draft,
+            metadataText = "18:03",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-yet-to-send",
+            text = "Queued outgoing row.",
+            status = Status.Outgoing.YetToSend,
+            metadataText = "18:04 \u2022 Sending",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-sending",
+            text = "Sending outgoing row.",
+            status = Status.Outgoing.Sending,
+            metadataText = "18:05 \u2022 Sending",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-resending",
+            text = "Retrying outgoing row.",
+            status = Status.Outgoing.Resending,
+            metadataText = "18:06 \u2022 Retrying",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-awaiting-retry",
+            text = "Awaiting retry outgoing row.",
+            status = Status.Outgoing.AwaitingRetry,
+            metadataText = "18:07 \u2022 Failed",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-failed",
+            text = "Failed outgoing row.",
+            status = Status.Outgoing.Failed,
+            metadataText = "18:08 \u2022 Failed",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-failed-emergency",
+            text = "Emergency-number failure row.",
+            status = Status.Outgoing.FailedEmergencyNumber,
+            metadataText = "18:09 \u2022 Failed",
+        ),
+        RowsStatusPreviewItem(
+            messageId = "rows-status-unknown",
+            text = "Unknown outgoing row.",
+            status = Status.Unknown,
+            metadataText = "18:10",
+        ),
+    )
+}
+
+internal fun conversationMessageRowsMmsDownloadPreviewItems(): List<RowsMmsDownloadPreviewItem> {
+    return listOf(
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-awaiting",
+            status = Status.Incoming.YetToManualDownload,
+            downloadState = MmsDownloadUiModel.State.AwaitingManualDownload,
+            canDownloadMessage = true,
+        ),
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-awaiting-disabled",
+            status = Status.Incoming.YetToManualDownload,
+            downloadState = MmsDownloadUiModel.State.AwaitingManualDownload,
+            canDownloadMessage = false,
+        ),
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-downloading",
+            status = Status.Incoming.ManualDownloading,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+            isSelected = true,
+            isSelectionMode = true,
+        ),
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-auto-downloading",
+            status = Status.Incoming.AutoDownloading,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+        ),
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-retrying",
+            status = Status.Incoming.RetryingManualDownload,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+        ),
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-auto-retrying",
+            status = Status.Incoming.RetryingAutoDownload,
+            downloadState = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+        ),
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-failed",
+            status = Status.Incoming.DownloadFailed,
+            downloadState = MmsDownloadUiModel.State.DownloadFailed,
+            canDownloadMessage = true,
+        ),
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-failed-disabled",
+            status = Status.Incoming.DownloadFailed,
+            downloadState = MmsDownloadUiModel.State.DownloadFailed,
+            canDownloadMessage = false,
+        ),
+        RowsMmsDownloadPreviewItem(
+            messageId = "rows-mms-expired",
+            status = Status.Incoming.ExpiredOrNotAvailable,
+            downloadState = MmsDownloadUiModel.State.ExpiredOrUnavailable,
+            canDownloadMessage = false,
+        ),
+    )
+}
+
+internal fun conversationMessageRowsPreviewHorizontalAlignment(
+    message: ConversationMessageUiModel,
+): Alignment.Horizontal {
+    return when {
+        message.isIncoming -> Alignment.Start
+        else -> Alignment.End
+    }
+}
+
+internal fun previewConversationMessageRowsLayout(
+    message: ConversationMessageUiModel,
+    showIncomingParticipantIdentity: Boolean,
+    metadataText: String?,
+): ConversationMessageLayout {
+    val showSender = message.isIncoming &&
+        showIncomingParticipantIdentity &&
+        !message.senderDisplayName.isNullOrBlank() &&
+        !message.canClusterWithPrevious
+    val showAvatarGutter = message.isIncoming && showIncomingParticipantIdentity
+    val showAvatar = showAvatarGutter && !message.canClusterWithNext
+    val content = buildConversationMessageContent(
+        message = message,
+        subjectText = message.mmsSubject,
+    )
+
+    return ConversationMessageLayout(
+        bubbleShape = previewConversationMessageRowsBubbleShape(message = message),
+        bubbleLayoutMode = previewConversationMessageRowsBubbleLayoutMode(
+            content = content,
+            showSender = showSender,
+        ),
+        content = content,
+        metadataText = previewConversationMessageRowsMetadataText(
+            message = message,
+            metadataText = metadataText,
+        ),
+        showSender = showSender,
+        showAvatarGutter = showAvatarGutter,
+        showAvatar = showAvatar,
+    )
+}
+
+private fun previewConversationMessageRowsBubbleLayoutMode(
+    content: ConversationMessageContent,
+    showSender: Boolean,
+): ConversationMessageBubbleLayoutMode {
+    val hasAttachments = content.attachments.isNotEmpty()
+    if (!hasAttachments) {
+        return ConversationMessageBubbleLayoutMode.TextInSurface
+    }
+
+    val hasAttachmentHeaderOrFooter = showSender ||
+        !content.subjectText.isNullOrBlank() ||
+        !content.bodyText.isNullOrBlank()
+
+    return when {
+        content.isAttachmentOnly && !hasAttachmentHeaderOrFooter -> {
+            ConversationMessageBubbleLayoutMode.AttachmentOnlyWithoutSurface
+        }
+
+        else -> ConversationMessageBubbleLayoutMode.AttachmentsInSurface
+    }
+}
+
+private fun previewConversationMessageRowsMetadataText(
+    message: ConversationMessageUiModel,
+    metadataText: String?,
+): String? {
+    return when {
+        message.mmsDownload != null -> null
+        message.canClusterWithNext -> null
+        else -> metadataText
+    }
+}
+
+private fun previewConversationMessageRowsBubbleShape(
+    message: ConversationMessageUiModel,
+): RoundedCornerShape {
+    val topStartCornerRadius = previewConversationMessageRowsClusteredCornerRadius(
+        clustersWithAdjacent = message.canClusterWithPrevious,
+    )
+    val topEndCornerRadius = previewConversationMessageRowsClusteredCornerRadius(
+        clustersWithAdjacent = message.canClusterWithPrevious,
+        useFreeSide = true,
+    )
+    val bottomStartCornerRadius = previewConversationMessageRowsClusteredCornerRadius(
+        clustersWithAdjacent = message.canClusterWithNext,
+    )
+    val bottomEndCornerRadius = previewConversationMessageRowsClusteredCornerRadius(
+        clustersWithAdjacent = message.canClusterWithNext,
+        useFreeSide = true,
+    )
+
+    return RoundedCornerShape(
+        topStart = if (message.isIncoming) topStartCornerRadius else topEndCornerRadius,
+        topEnd = if (message.isIncoming) topEndCornerRadius else topStartCornerRadius,
+        bottomStart = if (message.isIncoming) bottomStartCornerRadius else bottomEndCornerRadius,
+        bottomEnd = if (message.isIncoming) bottomEndCornerRadius else bottomStartCornerRadius,
+    )
+}
+
+private fun previewConversationMessageRowsClusteredCornerRadius(
+    clustersWithAdjacent: Boolean,
+    useFreeSide: Boolean = false,
+): Dp {
+    return when {
+        !clustersWithAdjacent -> PREVIEW_ROWS_BUBBLE_CORNER_RADIUS
+        useFreeSide -> PREVIEW_ROWS_BUBBLE_CORNER_RADIUS
+        else -> PREVIEW_ROWS_BUBBLE_CONNECTED_CORNER_RADIUS
+    }
+}

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageSelectionIndicator.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMessageSelectionIndicator.kt
@@ -17,7 +17,9 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
@@ -34,7 +36,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private val MESSAGE_SELECTION_INDICATOR_SIZE = 22.dp
 private val MESSAGE_SELECTION_INDICATOR_HORIZONTAL_GAP = 16.dp
@@ -251,4 +255,25 @@ private fun Transition<Boolean>.animateSelectionIndicatorCheckmarkScale(): State
             }
         },
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageSelectionIndicatorPreview() {
+    MessagingPreviewColumn {
+        Row(horizontalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            ConversationMessageSelectionIndicator(
+                visible = true,
+                isSelected = false,
+                expandFrom = Alignment.Start,
+                shrinkTowards = Alignment.Start,
+            )
+            ConversationMessageSelectionIndicator(
+                visible = true,
+                isSelected = true,
+                expandFrom = Alignment.Start,
+                shrinkTowards = Alignment.Start,
+            )
+        }
+    }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMmsDownloadBody.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMmsDownloadBody.kt
@@ -16,9 +16,12 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.messages.model.message.MmsDownloadUiModel
+import com.android.messaging.ui.conversation.preview.previewMmsDownloadUiModel
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 private const val MMS_DOWNLOAD_STATUS_SEPARATOR = " • "
 
@@ -220,5 +223,23 @@ private fun buildMmsDownloadStatusLineText(
     return when {
         simAnnotation == null -> statusText
         else -> "$statusText$MMS_DOWNLOAD_STATUS_SEPARATOR$simAnnotation"
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMmsDownloadBodyPreview() {
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            MmsDownloadUiModel.State.entries.forEach { state ->
+                ConversationMmsDownloadBody(
+                    download = previewMmsDownloadUiModel(state = state),
+                    canDownloadMessage = true,
+                    isSelected = state == MmsDownloadUiModel.State.Downloading,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                    simDisplayName = "Personal",
+                )
+            }
+        }
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/ui/text/ConversationMessageText.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/text/ConversationMessageText.kt
@@ -3,9 +3,16 @@ package com.android.messaging.ui.conversation.messages.ui.text
 import android.os.SystemClock
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
@@ -37,11 +44,29 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.messages.model.text.ConversationTextLink
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 private const val LINK_CLICK_SUPPRESSION_AFTER_LONG_PRESS_MILLIS = 500L
+private const val PREVIEW_PLAIN_TEXT = "Sounds good. I will be there in about 10 minutes."
+private const val PREVIEW_MULTILINE_TEXT = "First line from the message\n" +
+    "Second line with a little more detail\n" +
+    "Third line after an intentional line break"
+private const val PREVIEW_LONG_WRAPPING_TEXT = "This is a longer SMS body that should wrap " +
+    "across multiple lines in a narrow message bubble. It gives the preview enough text to show " +
+    "line height, paragraph density, and how links like https://example.com/details fit inside " +
+    "the same text layout."
+private const val PREVIEW_UNBROKEN_TEXT =
+    "SupercalifragilisticexpialidociousPreviewTokenWithoutNaturalBreaks1234567890"
+private const val PREVIEW_MIXED_LINK_TEXT = "Open https://example.com or call +31 6 2222 3333."
+private const val PREVIEW_EMAIL_LINK_TEXT = "Send the receipt to preview@example.com before 5 PM."
+private const val PREVIEW_ADDRESS_LINK_TEXT =
+    "Meet at 1600 Amphitheatre Parkway, Mountain View, CA."
+private const val PREVIEW_EMOJI_TEXT = "Dinner is ready \uD83C\uDF5C Bring drinks if you can."
 
 internal val LocalConversationMessageLinkColor: ProvidableCompositionLocal<Color?> =
     compositionLocalOf {
@@ -308,5 +333,164 @@ private fun buildConversationLinkedAnnotatedString(
         if (currentIndex < text.length) {
             append(text.substring(currentIndex))
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageTextBasicPreview() {
+    ConversationMessageTextPreviewColumn {
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_PLAIN_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_MULTILINE_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_EMOJI_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        ConversationMessageTextPreviewSample(
+            text = "",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageTextWrappingPreview() {
+    ConversationMessageTextPreviewColumn {
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_LONG_WRAPPING_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        ConversationMessageTextPreviewSample(
+            modifier = Modifier.width(width = 180.dp),
+            text = PREVIEW_LONG_WRAPPING_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        ConversationMessageTextPreviewSample(
+            modifier = Modifier.width(width = 180.dp),
+            text = PREVIEW_UNBROKEN_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageTextLinksPreview() {
+    ConversationMessageTextPreviewColumn {
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_MIXED_LINK_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_EMAIL_LINK_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_ADDRESS_LINK_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageTextTypographyPreview() {
+    ConversationMessageTextPreviewColumn {
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_PLAIN_TEXT,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_PLAIN_TEXT,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_PLAIN_TEXT,
+            style = MaterialTheme.typography.labelMedium,
+        )
+        ConversationMessageTextPreviewSample(
+            text = PREVIEW_PLAIN_TEXT,
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationMessageTextBubbleLinkColorPreview() {
+    ConversationMessageTextPreviewColumn {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+        ) {
+            CompositionLocalProvider(
+                LocalConversationMessageLinkColor provides MaterialTheme.colorScheme.onPrimary,
+            ) {
+                ConversationMessageText(
+                    modifier = Modifier.padding(all = 16.dp),
+                    text = PREVIEW_MIXED_LINK_TEXT,
+                    style = MaterialTheme.typography.bodyLarge,
+                    onExternalUriClick = {},
+                    onMessageLongClick = {},
+                )
+            }
+        }
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ) {
+            ConversationMessageText(
+                modifier = Modifier.padding(all = 16.dp),
+                text = PREVIEW_LONG_WRAPPING_TEXT,
+                style = MaterialTheme.typography.bodyLarge,
+                onExternalUriClick = {},
+                onMessageLongClick = {},
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConversationMessageTextPreviewColumn(content: @Composable () -> Unit) {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(space = 12.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ConversationMessageTextPreviewSample(
+    modifier: Modifier = Modifier,
+    text: String,
+    style: TextStyle,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+    ) {
+        ConversationMessageText(
+            modifier = Modifier.padding(all = 16.dp),
+            text = text,
+            style = style,
+            onExternalUriClick = {},
+            onMessageLongClick = {},
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/metadata/ui/ConversationTopAppBar.kt
+++ b/src/com/android/messaging/ui/conversation/metadata/ui/ConversationTopAppBar.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.core.text.BidiFormatter
 import androidx.core.text.TextDirectionHeuristicsCompat
@@ -69,7 +70,12 @@ import com.android.messaging.ui.conversation.CONVERSATION_TOP_APP_BAR_TITLE_TEST
 import com.android.messaging.ui.conversation.CONVERSATION_UNARCHIVE_BUTTON_TEST_TAG
 import com.android.messaging.ui.conversation.composer.model.ConversationSimSelectorUiState
 import com.android.messaging.ui.conversation.metadata.model.ConversationMetadataUiState
+import com.android.messaging.ui.conversation.preview.previewGroupMetadata
+import com.android.messaging.ui.conversation.preview.previewMetadata
+import com.android.messaging.ui.conversation.preview.previewSimSelectorUiState
 import com.android.messaging.ui.conversation.resolveDisplayName
+import com.android.messaging.ui.core.MessagingPreviewColumn
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import com.android.messaging.util.AccessibilityUtil
 
 private val CONVERSATION_TOP_APP_BAR_TITLE_SPACING = 12.dp
@@ -646,4 +652,79 @@ private data class ConversationTopAppBarOverflowVisibility(
                 isShowSubjectFieldVisible ||
                 isSimSelectorVisible
         }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationTopAppBarLoadingPreview() {
+    MessagingPreviewTheme {
+        ConversationTopAppBar(
+            metadata = ConversationMetadataUiState.Loading,
+            onAddPeopleClick = {},
+            onTitleClick = {},
+            onNavigateBack = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationTopAppBarOneOnOnePreview() {
+    MessagingPreviewTheme {
+        ConversationTopAppBar(
+            metadata = previewMetadata(),
+            isCallVisible = true,
+            isArchiveVisible = true,
+            isAddContactVisible = true,
+            isDeleteConversationVisible = true,
+            isShowSubjectFieldVisible = true,
+            simSelector = previewSimSelectorUiState(),
+            onAddPeopleClick = {},
+            onTitleClick = {},
+            onNavigateBack = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationTopAppBarGroupPreview() {
+    MessagingPreviewTheme {
+        ConversationTopAppBar(
+            metadata = previewGroupMetadata(),
+            isAddPeopleVisible = true,
+            isUnarchiveVisible = true,
+            isDeleteConversationVisible = true,
+            onAddPeopleClick = {},
+            onTitleClick = {},
+            onNavigateBack = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationTopAppBarOverflowMenuContentPreview() {
+    MessagingPreviewColumn {
+        ConversationTopAppBarOverflowMenuContent(
+            visibility = ConversationTopAppBarOverflowVisibility(
+                isAddPeopleVisible = true,
+                isArchiveVisible = true,
+                isUnarchiveVisible = true,
+                isAddContactVisible = true,
+                isDeleteConversationVisible = true,
+                isShowSubjectFieldVisible = true,
+                isSimSelectorVisible = true,
+            ),
+            simSelectorLabel = "Personal",
+            onAddPeopleClick = {},
+            onArchiveClick = {},
+            onUnarchiveClick = {},
+            onAddContactClick = {},
+            onDeleteConversationClick = {},
+            onShowSubjectFieldClick = {},
+            onSimSelectorClick = {},
+            onItemClick = { action -> action() },
+        )
+    }
 }

--- a/src/com/android/messaging/ui/conversation/preview/ConversationPreviewData.kt
+++ b/src/com/android/messaging/ui/conversation/preview/ConversationPreviewData.kt
@@ -1,0 +1,605 @@
+@file:Suppress("TooManyFunctions")
+
+package com.android.messaging.ui.conversation.preview
+
+import androidx.core.net.toUri
+import com.android.messaging.R
+import com.android.messaging.data.conversation.model.attachment.ConversationVCardAttachmentType
+import com.android.messaging.data.conversation.model.metadata.ConversationComposerAvailability
+import com.android.messaging.data.conversation.model.metadata.ConversationSubscriptionLabel
+import com.android.messaging.data.subscription.model.Subscription
+import com.android.messaging.domain.conversation.usecase.draft.model.ConversationDraftSendProtocol
+import com.android.messaging.ui.contact.model.ContactDestinationUiModel
+import com.android.messaging.ui.contact.model.ContactUiModel
+import com.android.messaging.ui.conversation.attachment.model.ConversationVCardAttachmentUiModel
+import com.android.messaging.ui.conversation.audio.model.ConversationAudioRecordingPhase
+import com.android.messaging.ui.conversation.audio.model.ConversationAudioRecordingUiState
+import com.android.messaging.ui.conversation.composer.model.ComposerAttachmentUiModel
+import com.android.messaging.ui.conversation.composer.model.ConversationComposerUiState
+import com.android.messaging.ui.conversation.composer.model.ConversationSegmentCounterUiState
+import com.android.messaging.ui.conversation.composer.model.ConversationSimSelectorUiState
+import com.android.messaging.ui.conversation.messages.model.attachment.ConversationAttachmentItem
+import com.android.messaging.ui.conversation.messages.model.attachment.ConversationAttachmentOpenAction
+import com.android.messaging.ui.conversation.messages.model.attachment.ConversationAttachmentSections
+import com.android.messaging.ui.conversation.messages.model.attachment.ConversationInlineAttachment
+import com.android.messaging.ui.conversation.messages.model.attachment.ConversationMessageAttachment
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessagePartUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessagesUiState
+import com.android.messaging.ui.conversation.messages.model.message.MmsDownloadUiModel
+import com.android.messaging.ui.conversation.metadata.model.ConversationMetadataUiState
+import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerListItem
+import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerUiState
+import com.android.messaging.ui.conversation.recipientpicker.model.picker.SelectedRecipient
+import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionContentUiState
+import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionPrimaryActionUiState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+private const val PREVIEW_NOW_MILLIS = 1_806_240_000_000L
+private const val PREVIEW_MESSAGE_RECEIVED_MILLIS = PREVIEW_NOW_MILLIS - 120_000L
+private const val PREVIEW_IMAGE_WIDTH = 1600
+private const val PREVIEW_IMAGE_HEIGHT = 1200
+
+internal fun previewSubscriptions(): ImmutableList<Subscription> {
+    return persistentListOf(
+        previewSubscription(
+            selfParticipantId = "self-1",
+            subId = 1,
+            label = ConversationSubscriptionLabel.Named(name = "Personal"),
+            displayDestination = "+31 6 1234 5678",
+            displaySlotId = 1,
+            color = 0xff1e88e5.toInt(),
+        ),
+        previewSubscription(
+            selfParticipantId = "self-2",
+            subId = 2,
+            label = ConversationSubscriptionLabel.Named(name = "Work"),
+            displayDestination = "+372 5555 0101",
+            displaySlotId = 2,
+            color = 0xff43a047.toInt(),
+        ),
+    )
+}
+
+internal fun previewSubscription(
+    selfParticipantId: String = "self-1",
+    subId: Int = 1,
+    label: ConversationSubscriptionLabel = ConversationSubscriptionLabel.Named(name = "Personal"),
+    displayDestination: String? = "+31 6 1234 5678",
+    displaySlotId: Int = 1,
+    color: Int = 0xff1e88e5.toInt(),
+): Subscription {
+    return Subscription(
+        selfParticipantId = selfParticipantId,
+        subId = subId,
+        label = label,
+        displayDestination = displayDestination,
+        displaySlotId = displaySlotId,
+        color = color,
+    )
+}
+
+internal fun previewSimSelectorUiState(): ConversationSimSelectorUiState {
+    val subscriptions = previewSubscriptions()
+    return ConversationSimSelectorUiState(
+        subscriptions = subscriptions,
+        selectedSubscription = subscriptions.first(),
+        isLoading = false,
+    )
+}
+
+internal fun previewMetadata(
+    title: String = "Ada Lovelace",
+    participantCount: Int = 1,
+): ConversationMetadataUiState.Present {
+    return ConversationMetadataUiState.Present(
+        title = title,
+        selfParticipantId = "self-1",
+        avatar = ConversationMetadataUiState.Avatar.Single(photoUri = null),
+        participantCount = participantCount,
+        otherParticipantDisplayDestination = "+31 6 2222 3333",
+        otherParticipantPhoneNumber = "+31622223333",
+        otherParticipantContactLookupKey = "preview-contact",
+        isArchived = false,
+        composerAvailability = ConversationComposerAvailability.Editable,
+    )
+}
+
+internal fun previewGroupMetadata(): ConversationMetadataUiState.Present {
+    return ConversationMetadataUiState.Present(
+        title = "Project group",
+        selfParticipantId = "self-1",
+        avatar = ConversationMetadataUiState.Avatar.Group,
+        participantCount = 4,
+        otherParticipantDisplayDestination = null,
+        otherParticipantPhoneNumber = null,
+        otherParticipantContactLookupKey = null,
+        isArchived = false,
+        composerAvailability = ConversationComposerAvailability.Editable,
+    )
+}
+
+internal fun previewComposerUiState(
+    messageText: String = "Sounds good, see you at 18:30.",
+    subjectText: String = "",
+): ConversationComposerUiState {
+    return ConversationComposerUiState(
+        attachments = persistentListOf(),
+        messageText = messageText,
+        subjectText = subjectText,
+        selfParticipantId = "self-1",
+        simSelector = previewSimSelectorUiState(),
+        isMessageFieldEnabled = true,
+        isAttachmentActionEnabled = true,
+        isRecordActionEnabled = true,
+        isSendEnabled = messageText.isNotBlank() || subjectText.isNotBlank(),
+        shouldShowRecordAction = messageText.isBlank() && subjectText.isBlank(),
+        hasWorkingDraft = messageText.isNotBlank() || subjectText.isNotBlank(),
+        sendProtocol = ConversationDraftSendProtocol.SMS,
+        attachmentCount = 0,
+        pendingAttachmentCount = 0,
+        segmentCounter = ConversationSegmentCounterUiState(
+            codePointsRemainingInCurrentMessage = 78,
+            messageCount = 1,
+        ),
+    )
+}
+
+internal fun previewComposerWithAttachments(): ConversationComposerUiState {
+    return previewComposerUiState(
+        messageText = "Sharing the files from today.",
+        subjectText = "Meeting notes",
+    ).copy(
+        attachments = persistentListOf(
+            previewPendingAttachment(),
+            previewResolvedImageAttachment(),
+            previewResolvedAudioAttachment(),
+            previewResolvedVCardAttachment(),
+        ),
+        sendProtocol = ConversationDraftSendProtocol.MMS,
+        attachmentCount = 4,
+        pendingAttachmentCount = 1,
+        segmentCounter = null,
+    )
+}
+
+internal fun previewRecordingComposer(
+    isLocked: Boolean = false,
+): ConversationComposerUiState {
+    return previewComposerUiState(messageText = "").copy(
+        audioRecording = ConversationAudioRecordingUiState(
+            phase = ConversationAudioRecordingPhase.Recording,
+            durationMillis = 41_000L,
+            isLocked = isLocked,
+        ),
+        isSendEnabled = false,
+        shouldShowRecordAction = true,
+    )
+}
+
+internal fun previewPendingAttachment(): ComposerAttachmentUiModel.Pending.Generic {
+    return ComposerAttachmentUiModel.Pending.Generic(
+        key = "pending-file",
+        contentType = "application/pdf",
+        contentUri = "content://com.android.messaging.preview/pending/file.pdf",
+        displayName = "Meeting agenda.pdf",
+    )
+}
+
+internal fun previewPendingAudioAttachment(): ComposerAttachmentUiModel.Pending.AudioFinalizing {
+    return ComposerAttachmentUiModel.Pending.AudioFinalizing(
+        key = "pending-audio",
+        contentType = "audio/ogg",
+        contentUri = "content://com.android.messaging.preview/pending/audio.ogg",
+        displayName = "Recording.ogg",
+    )
+}
+
+internal fun previewResolvedImageAttachment():
+    ComposerAttachmentUiModel.Resolved.VisualMedia.Image {
+    return ComposerAttachmentUiModel.Resolved.VisualMedia.Image(
+        key = "image-attachment",
+        contentType = "image/jpeg",
+        contentUri = "content://com.android.messaging.preview/image.jpg",
+        captionText = "Photo from the event",
+        width = PREVIEW_IMAGE_WIDTH,
+        height = PREVIEW_IMAGE_HEIGHT,
+    )
+}
+
+internal fun previewResolvedVideoAttachment():
+    ComposerAttachmentUiModel.Resolved.VisualMedia.Video {
+    return ComposerAttachmentUiModel.Resolved.VisualMedia.Video(
+        key = "video-attachment",
+        contentType = "video/mp4",
+        contentUri = "content://com.android.messaging.preview/video.mp4",
+        captionText = "Short clip",
+        width = 1920,
+        height = 1080,
+    )
+}
+
+internal fun previewResolvedAudioAttachment(): ComposerAttachmentUiModel.Resolved.Audio {
+    return ComposerAttachmentUiModel.Resolved.Audio(
+        key = "audio-attachment",
+        contentType = "audio/ogg",
+        contentUri = "content://com.android.messaging.preview/audio.ogg",
+        durationMillis = 72_000L,
+    )
+}
+
+internal fun previewResolvedFileAttachment(): ComposerAttachmentUiModel.Resolved.File {
+    return ComposerAttachmentUiModel.Resolved.File(
+        key = "file-attachment",
+        contentType = "application/pdf",
+        contentUri = "content://com.android.messaging.preview/document.pdf",
+    )
+}
+
+internal fun previewResolvedVCardAttachment(): ComposerAttachmentUiModel.Resolved.VCard {
+    return ComposerAttachmentUiModel.Resolved.VCard(
+        key = "vcard-attachment",
+        contentType = "text/vcard",
+        contentUri = "content://com.android.messaging.preview/contact.vcf",
+        vCardUiModel = previewVCardUiModel(),
+    )
+}
+
+internal fun previewVCardUiModel(
+    type: ConversationVCardAttachmentType = ConversationVCardAttachmentType.CONTACT,
+): ConversationVCardAttachmentUiModel {
+    return ConversationVCardAttachmentUiModel(
+        type = type,
+        avatarUri = null,
+        titleText = when (type) {
+            ConversationVCardAttachmentType.CONTACT -> "Ada Lovelace"
+            ConversationVCardAttachmentType.LOCATION -> "Rathausmarkt"
+        },
+        subtitleText = when (type) {
+            ConversationVCardAttachmentType.CONTACT -> "+31 6 2222 3333"
+            ConversationVCardAttachmentType.LOCATION -> "Hamburg, Germany"
+        },
+    )
+}
+
+internal fun previewMessagesUiState(): ConversationMessagesUiState.Present {
+    return ConversationMessagesUiState.Present(messages = previewMessages())
+}
+
+internal fun previewMessages(): ImmutableList<ConversationMessageUiModel> {
+    return persistentListOf(
+        previewIncomingMessage(
+            messageId = "incoming-mms",
+            text = "Here are the photos and voice note.",
+            status = ConversationMessageUiModel.Status.Incoming.Complete,
+            parts = persistentListOf(
+                previewImagePart(text = null),
+                previewAudioPart(text = "Voice note"),
+            ),
+            canSaveAttachments = true,
+        ),
+        previewOutgoingMessage(
+            messageId = "outgoing-delivered",
+            text = "Received. I will forward them to the group.",
+            status = ConversationMessageUiModel.Status.Outgoing.Delivered,
+        ),
+        previewIncomingMessage(
+            messageId = "incoming-download",
+            text = null,
+            status = ConversationMessageUiModel.Status.Incoming.YetToManualDownload,
+            mmsDownload = previewMmsDownloadUiModel(),
+            protocol = ConversationMessageUiModel.Protocol.MMS_PUSH_NOTIFICATION,
+            canDownloadMessage = true,
+        ),
+    )
+}
+
+internal fun previewIncomingMessage(
+    messageId: String = "incoming-1",
+    text: String? = "Can you review this before tonight?",
+    status: ConversationMessageUiModel.Status = ConversationMessageUiModel.Status.Incoming.Complete,
+    parts: ImmutableList<ConversationMessagePartUiModel> = persistentListOf(
+        ConversationMessagePartUiModel.Text(text = text ?: "Preview message"),
+    ),
+    mmsDownload: MmsDownloadUiModel? = null,
+    protocol: ConversationMessageUiModel.Protocol = ConversationMessageUiModel.Protocol.SMS,
+    canDownloadMessage: Boolean = false,
+    canSaveAttachments: Boolean = false,
+): ConversationMessageUiModel {
+    return previewMessage(
+        messageId = messageId,
+        text = text,
+        parts = parts,
+        status = status,
+        isIncoming = true,
+        senderDisplayName = "Ada Lovelace",
+        senderParticipantId = "participant-ada",
+        mmsDownload = mmsDownload,
+        protocol = protocol,
+        canDownloadMessage = canDownloadMessage,
+        canSaveAttachments = canSaveAttachments,
+    )
+}
+
+internal fun previewOutgoingMessage(
+    messageId: String = "outgoing-1",
+    text: String? = "I am on my way.",
+    status: ConversationMessageUiModel.Status = ConversationMessageUiModel.Status.Outgoing.Complete,
+    parts: ImmutableList<ConversationMessagePartUiModel> = persistentListOf(
+        ConversationMessagePartUiModel.Text(text = text ?: "Preview reply"),
+    ),
+): ConversationMessageUiModel {
+    return previewMessage(
+        messageId = messageId,
+        text = text,
+        parts = parts,
+        status = status,
+        isIncoming = false,
+        senderDisplayName = null,
+        senderParticipantId = "self-1",
+        selfParticipantId = "self-1",
+    )
+}
+
+internal fun previewMessageAttachments(): ImmutableList<ConversationMessageAttachment> {
+    return persistentListOf(
+        ConversationMessageAttachment.Media(
+            key = "message-image",
+            part = previewImagePart(text = "Image caption"),
+        ),
+        ConversationMessageAttachment.Media(
+            key = "message-video",
+            part = previewVideoPart(text = "Video caption"),
+        ),
+        ConversationMessageAttachment.Unsupported(
+            key = "message-file",
+            part = previewFilePart(text = "Unsupported file"),
+        ),
+    )
+}
+
+internal fun previewAttachmentSections(): ConversationAttachmentSections {
+    val attachments = previewMessageAttachments()
+    return ConversationAttachmentSections(
+        galleryVisualAttachments = persistentListOf(attachments[0], attachments[1]),
+        trailingItems = persistentListOf(
+            ConversationAttachmentItem.Inline(
+                key = "inline-audio",
+                attachment = previewInlineAudioAttachment(),
+            ),
+            ConversationAttachmentItem.Inline(
+                key = "inline-vcard",
+                attachment = previewInlineVCardAttachment(),
+            ),
+        ),
+    )
+}
+
+internal fun previewImagePart(text: String?): ConversationMessagePartUiModel.Attachment.Image {
+    return ConversationMessagePartUiModel.Attachment.Image(
+        text = text,
+        contentType = "image/jpeg",
+        contentUri = "content://com.android.messaging.preview/message/image.jpg".toUri(),
+        width = PREVIEW_IMAGE_WIDTH,
+        height = PREVIEW_IMAGE_HEIGHT,
+    )
+}
+
+internal fun previewVideoPart(text: String?): ConversationMessagePartUiModel.Attachment.Video {
+    return ConversationMessagePartUiModel.Attachment.Video(
+        text = text,
+        contentType = "video/mp4",
+        contentUri = "content://com.android.messaging.preview/message/video.mp4".toUri(),
+        width = 1920,
+        height = 1080,
+    )
+}
+
+internal fun previewAudioPart(text: String?): ConversationMessagePartUiModel.Attachment.Audio {
+    return ConversationMessagePartUiModel.Attachment.Audio(
+        text = text,
+        contentType = "audio/ogg",
+        contentUri = "content://com.android.messaging.preview/message/audio.ogg".toUri(),
+        width = 0,
+        height = 0,
+    )
+}
+
+internal fun previewFilePart(text: String?): ConversationMessagePartUiModel.Attachment.File {
+    return ConversationMessagePartUiModel.Attachment.File(
+        text = text,
+        contentType = "application/pdf",
+        contentUri = "content://com.android.messaging.preview/message/file.pdf".toUri(),
+        width = 0,
+        height = 0,
+    )
+}
+
+internal fun previewVCardPart(): ConversationMessagePartUiModel.Attachment.VCard {
+    return ConversationMessagePartUiModel.Attachment.VCard(
+        text = null,
+        contentType = "text/vcard",
+        contentUri = "content://com.android.messaging.preview/message/contact.vcf".toUri(),
+        width = 0,
+        height = 0,
+        vCardUiModel = previewVCardUiModel(),
+    )
+}
+
+internal fun previewInlineAudioAttachment(): ConversationInlineAttachment.Audio {
+    return ConversationInlineAttachment.Audio(
+        key = "inline-audio",
+        contentUri = "content://com.android.messaging.preview/message/audio.ogg",
+        openAction = ConversationAttachmentOpenAction.OpenContent(
+            contentType = "audio/ogg",
+            contentUri = "content://com.android.messaging.preview/message/audio.ogg",
+        ),
+        titleText = "Voice note",
+        titleTextResId = null,
+    )
+}
+
+internal fun previewInlineFileAttachment(): ConversationInlineAttachment.File {
+    return ConversationInlineAttachment.File(
+        key = "inline-file",
+        openAction = ConversationAttachmentOpenAction.OpenContent(
+            contentType = "application/pdf",
+            contentUri = "content://com.android.messaging.preview/message/file.pdf",
+        ),
+        subtitleTextResId = R.string.notification_file,
+        titleText = "Quarterly report.pdf",
+        titleTextResId = null,
+    )
+}
+
+internal fun previewInlineVCardAttachment(
+    type: ConversationVCardAttachmentType = ConversationVCardAttachmentType.CONTACT,
+): ConversationInlineAttachment.VCard {
+    val vCardUiModel = previewVCardUiModel(type = type)
+    return ConversationInlineAttachment.VCard(
+        key = "inline-vcard",
+        contentUri = "content://com.android.messaging.preview/message/contact.vcf",
+        openAction = ConversationAttachmentOpenAction.OpenContent(
+            contentType = "text/vcard",
+            contentUri = "content://com.android.messaging.preview/message/contact.vcf",
+        ),
+        type = type,
+        avatarUri = vCardUiModel.avatarUri,
+        titleText = vCardUiModel.titleText,
+        titleTextResId = vCardUiModel.titleTextResId,
+        subtitleText = vCardUiModel.subtitleText,
+        subtitleTextResId = vCardUiModel.subtitleTextResId,
+    )
+}
+
+internal fun previewMmsDownloadUiModel(
+    state: MmsDownloadUiModel.State = MmsDownloadUiModel.State.AwaitingManualDownload,
+): MmsDownloadUiModel {
+    return MmsDownloadUiModel(
+        state = state,
+        sizeBytes = 2_400_000L,
+        expiryTimestamp = PREVIEW_NOW_MILLIS + 86_400_000L,
+    )
+}
+
+internal fun previewRecipientPickerUiState(): RecipientPickerUiState {
+    return RecipientPickerUiState(
+        query = "Ada",
+        items = persistentListOf(
+            RecipientPickerListItem.Contact(contact = previewContact()),
+            RecipientPickerListItem.SyntheticPhone(
+                id = "synthetic:+31655550199",
+                rawQuery = "+31 6 5555 0199",
+                destination = "+31655550199",
+                normalizedDestination = "+31655550199",
+                displayName = "+31 6 5555 0199",
+                secondaryText = "Mobile",
+            ),
+        ),
+        canLoadMore = true,
+        hasContactsPermission = true,
+        isLoading = false,
+        isLoadingMore = false,
+    )
+}
+
+internal fun previewRecipientSelectionContentUiState(): RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = previewRecipientPickerUiState(),
+        primaryAction = RecipientSelectionPrimaryActionUiState(
+            text = "Start chat",
+            isEnabled = true,
+        ),
+        selectedRecipients = persistentListOf(previewSelectedRecipient()),
+        isQueryEnabled = true,
+    )
+}
+
+internal fun previewSelectedRecipient(): SelectedRecipient {
+    return SelectedRecipient(
+        destination = "+31622223333",
+        label = "Ada Lovelace",
+        displayDestination = "+31 6 2222 3333",
+        photoUri = null,
+    )
+}
+
+internal fun previewContact(): ContactUiModel {
+    return ContactUiModel(
+        id = 1L,
+        lookupKey = "preview-contact",
+        displayName = "Ada Lovelace",
+        photoUri = null,
+        destinations = persistentListOf(
+            ContactDestinationUiModel(
+                dataId = 11L,
+                contactId = 1L,
+                value = "+31 6 2222 3333",
+                normalizedValue = "+31622223333",
+                displayValue = "+31 6 2222 3333",
+                kind = ContactDestinationUiModel.Kind.PHONE,
+                type = 2,
+                customLabel = null,
+                isPrimary = true,
+                isSuperPrimary = true,
+            ),
+            ContactDestinationUiModel(
+                dataId = 12L,
+                contactId = 1L,
+                value = "ada@example.com",
+                normalizedValue = "ada@example.com",
+                displayValue = "ada@example.com",
+                kind = ContactDestinationUiModel.Kind.EMAIL,
+                type = 1,
+                customLabel = null,
+                isPrimary = false,
+                isSuperPrimary = false,
+            ),
+        ),
+    )
+}
+
+private fun previewMessage(
+    messageId: String,
+    text: String?,
+    parts: ImmutableList<ConversationMessagePartUiModel>,
+    status: ConversationMessageUiModel.Status,
+    isIncoming: Boolean,
+    senderDisplayName: String?,
+    senderParticipantId: String?,
+    selfParticipantId: String? = null,
+    mmsDownload: MmsDownloadUiModel? = null,
+    protocol: ConversationMessageUiModel.Protocol = ConversationMessageUiModel.Protocol.SMS,
+    canDownloadMessage: Boolean = false,
+    canSaveAttachments: Boolean = false,
+): ConversationMessageUiModel {
+    return ConversationMessageUiModel(
+        messageId = messageId,
+        conversationId = "conversation-1",
+        text = text,
+        parts = parts,
+        sentTimestamp = PREVIEW_MESSAGE_RECEIVED_MILLIS,
+        receivedTimestamp = PREVIEW_MESSAGE_RECEIVED_MILLIS,
+        displayTimestamp = PREVIEW_MESSAGE_RECEIVED_MILLIS,
+        status = status,
+        isIncoming = isIncoming,
+        senderDisplayName = senderDisplayName,
+        senderAvatarUri = null,
+        senderContactId = 1L,
+        senderContactLookupKey = "preview-contact",
+        senderNormalizedDestination = "+31622223333",
+        senderParticipantId = senderParticipantId,
+        selfParticipantId = selfParticipantId,
+        canClusterWithPrevious = false,
+        canClusterWithNext = false,
+        canCopyMessageToClipboard = !text.isNullOrBlank(),
+        canDownloadMessage = canDownloadMessage,
+        canForwardMessage = true,
+        canResendMessage = status == ConversationMessageUiModel.Status.Outgoing.Failed,
+        canSaveAttachments = canSaveAttachments,
+        mmsDownload = mmsDownload,
+        mmsSubject = null,
+        protocol = protocol,
+    )
+}

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/MultiDestinationContactRow.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/MultiDestinationContactRow.kt
@@ -50,11 +50,28 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.contact.model.ContactDestinationUiModel
+import com.android.messaging.ui.conversation.preview.previewRecipientPickerUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerListItem
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionRowDecorators
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+
+private const val PREVIEW_MOBILE_DESTINATION = "+31622223333"
+private const val PREVIEW_WORK_DESTINATION = "+31644445555"
+private const val PREVIEW_HOME_DESTINATION = "+31677778888"
+private const val PREVIEW_EMAIL_DESTINATION = "ada@example.com"
+private const val PREVIEW_LONG_CONTACT_NAME =
+    "Alexandria Cassandra Montgomery-Washington from International Partnerships"
+private const val PREVIEW_LONG_PHONE_DESTINATION = "+1 415 555 0198 ext. 4827"
+private const val PREVIEW_LONG_EMAIL_DESTINATION =
+    "alexandria.montgomery-washington@international-partnerships.example"
+private const val PREVIEW_LONG_LOCATION_DESTINATION =
+    "northwest-visitor-center-routing-desk@example.com"
 
 private val avatarSize = 40.dp
 private val destinationVerticalPadding = 10.dp
@@ -364,5 +381,248 @@ private fun rememberDestinationHighlightShape(
         topEnd = topCornerRadius,
         bottomStart = bottomCornerRadius,
         bottomEnd = bottomCornerRadius,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun MultiDestinationContactRowSelectionStatesPreview() {
+    val contactItem = previewMultiDestinationContactItem()
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf(),
+            )
+
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf(PREVIEW_WORK_DESTINATION),
+            )
+
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf<String>()
+                    .add(PREVIEW_MOBILE_DESTINATION)
+                    .add(PREVIEW_WORK_DESTINATION)
+                    .add(PREVIEW_HOME_DESTINATION),
+            )
+
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf<String>()
+                    .add(PREVIEW_MOBILE_DESTINATION)
+                    .add(PREVIEW_WORK_DESTINATION)
+                    .add(PREVIEW_HOME_DESTINATION)
+                    .add(PREVIEW_EMAIL_DESTINATION),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun MultiDestinationContactRowContentStatesPreview() {
+    val contactItem = previewLongMultiDestinationContactItem()
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.width(width = 320.dp),
+            verticalArrangement = Arrangement.spacedBy(space = 12.dp),
+        ) {
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf(PREVIEW_LONG_PHONE_DESTINATION),
+            )
+
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf<String>()
+                    .add(PREVIEW_LONG_EMAIL_DESTINATION)
+                    .add(PREVIEW_LONG_LOCATION_DESTINATION),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun MultiDestinationContactRowInteractionStatesPreview() {
+    val contactItem = previewMultiDestinationContactItem()
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf(),
+                enabled = false,
+                onDestinationLongClick = null,
+            )
+
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf(PREVIEW_MOBILE_DESTINATION),
+                enabled = false,
+                loadingDestination = PREVIEW_EMAIL_DESTINATION,
+                onDestinationLongClick = null,
+            )
+
+            PreviewMultiDestinationContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf(PREVIEW_EMAIL_DESTINATION),
+                loadingDestination = PREVIEW_EMAIL_DESTINATION,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreviewMultiDestinationContactRow(
+    item: RecipientPickerListItem.Contact,
+    selectedDestinations: ImmutableSet<String>,
+    enabled: Boolean = true,
+    loadingDestination: String? = null,
+    onDestinationLongClick: ((destination: String) -> Unit)? = { _ -> },
+) {
+    MultiDestinationContactRow(
+        item = item,
+        enabled = enabled,
+        selectedDestinations = selectedDestinations,
+        onDestinationClick = { _ -> },
+        onDestinationLongClick = onDestinationLongClick,
+        shape = RoundedCornerShape(size = 20.dp),
+        rowDecorators = previewRecipientSelectionRowDecorators(
+            loadingDestination = loadingDestination,
+        ),
+    )
+}
+
+private fun previewRecipientSelectionRowDecorators(
+    loadingDestination: String?,
+): RecipientSelectionRowDecorators {
+    return RecipientSelectionRowDecorators(
+        recipientRowTestTag = { item -> item.id },
+        destinationRowTestTag = { item, destination -> "${item.id}:$destination" },
+        showRecipientTrailingIndicator = { _, destination ->
+            destination == loadingDestination
+        },
+    )
+}
+
+private fun previewMultiDestinationContactItem(): RecipientPickerListItem.Contact {
+    val baseContact = previewRecipientPickerUiState()
+        .items
+        .filterIsInstance<RecipientPickerListItem.Contact>()
+        .first()
+        .contact
+
+    return RecipientPickerListItem.Contact(
+        contact = baseContact.copy(
+            destinations = persistentListOf<ContactDestinationUiModel>()
+                .add(
+                    previewContactDestination(
+                        dataId = 11L,
+                        value = PREVIEW_MOBILE_DESTINATION,
+                        displayValue = "+31 6 2222 3333",
+                        kind = ContactDestinationUiModel.Kind.PHONE,
+                        type = Phone.TYPE_MOBILE,
+                        isPrimary = true,
+                        isSuperPrimary = true,
+                    ),
+                )
+                .add(
+                    previewContactDestination(
+                        dataId = 12L,
+                        value = PREVIEW_WORK_DESTINATION,
+                        displayValue = "+31 6 4444 5555",
+                        kind = ContactDestinationUiModel.Kind.PHONE,
+                        type = Phone.TYPE_WORK,
+                    ),
+                )
+                .add(
+                    previewContactDestination(
+                        dataId = 13L,
+                        value = PREVIEW_HOME_DESTINATION,
+                        displayValue = "+31 6 7777 8888",
+                        kind = ContactDestinationUiModel.Kind.PHONE,
+                        type = Phone.TYPE_HOME,
+                    ),
+                )
+                .add(
+                    previewContactDestination(
+                        dataId = 14L,
+                        value = PREVIEW_EMAIL_DESTINATION,
+                        displayValue = PREVIEW_EMAIL_DESTINATION,
+                        kind = ContactDestinationUiModel.Kind.EMAIL,
+                        type = Email.TYPE_HOME,
+                    ),
+                ),
+        ),
+    )
+}
+
+private fun previewLongMultiDestinationContactItem(): RecipientPickerListItem.Contact {
+    val baseContact = previewRecipientPickerUiState()
+        .items
+        .filterIsInstance<RecipientPickerListItem.Contact>()
+        .first()
+        .contact
+
+    return RecipientPickerListItem.Contact(
+        contact = baseContact.copy(
+            displayName = PREVIEW_LONG_CONTACT_NAME,
+            destinations = persistentListOf<ContactDestinationUiModel>()
+                .add(
+                    previewContactDestination(
+                        dataId = 21L,
+                        value = PREVIEW_LONG_PHONE_DESTINATION,
+                        displayValue = PREVIEW_LONG_PHONE_DESTINATION,
+                        kind = ContactDestinationUiModel.Kind.PHONE,
+                        type = Phone.TYPE_CUSTOM,
+                        customLabel = "Emergency escalation mobile",
+                    ),
+                )
+                .add(
+                    previewContactDestination(
+                        dataId = 22L,
+                        value = PREVIEW_LONG_EMAIL_DESTINATION,
+                        displayValue = PREVIEW_LONG_EMAIL_DESTINATION,
+                        kind = ContactDestinationUiModel.Kind.EMAIL,
+                        type = Email.TYPE_WORK,
+                    ),
+                )
+                .add(
+                    previewContactDestination(
+                        dataId = 23L,
+                        value = PREVIEW_LONG_LOCATION_DESTINATION,
+                        displayValue = PREVIEW_LONG_LOCATION_DESTINATION,
+                        kind = ContactDestinationUiModel.Kind.EMAIL,
+                        type = Email.TYPE_CUSTOM,
+                        customLabel = "Visitor center routing desk",
+                    ),
+                ),
+        ),
+    )
+}
+
+private fun previewContactDestination(
+    dataId: Long,
+    value: String,
+    displayValue: String,
+    kind: ContactDestinationUiModel.Kind,
+    type: Int,
+    customLabel: String? = null,
+    isPrimary: Boolean = false,
+    isSuperPrimary: Boolean = false,
+): ContactDestinationUiModel {
+    return ContactDestinationUiModel(
+        dataId = dataId,
+        contactId = 1L,
+        value = value,
+        normalizedValue = value,
+        displayValue = displayValue,
+        kind = kind,
+        type = type,
+        customLabel = customLabel,
+        isPrimary = isPrimary,
+        isSuperPrimary = isSuperPrimary,
     )
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactAvatar.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactAvatar.kt
@@ -12,7 +12,9 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -29,10 +31,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.android.messaging.R
+import com.android.messaging.ui.conversation.preview.previewRecipientPickerUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerListItem
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Composable
 internal fun RecipientSelectionContactAvatar(
@@ -207,4 +212,23 @@ private fun rememberRecipientSelectionContactAvatarScale(
             }
         },
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactAvatarPreview() {
+    MessagingPreviewColumn {
+        Row(horizontalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            previewRecipientPickerUiState().items.forEach { item ->
+                RecipientSelectionContactAvatar(
+                    item = item,
+                    isSelected = false,
+                )
+                RecipientSelectionContactAvatar(
+                    item = item,
+                    isSelected = true,
+                )
+            }
+        }
+    }
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactRow.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactRow.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -37,11 +38,14 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.contact.model.ContactDestinationUiModel
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerListItem
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionRowDecorators
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
 
 internal val contactCornerRadius = 18.dp
 internal val contactMiddleCornerRadius = 2.dp
@@ -435,4 +439,163 @@ internal fun Transition<Boolean>.animateSecondaryTextColor(): State<Color> {
             }
         },
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactRowGroupedListPreview() {
+    val items = previewRecipientSelectionContactRowGroupedItems()
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 4.dp)) {
+            items.forEachIndexed { index, item ->
+                PreviewRecipientSelectionContactRow(
+                    item = item,
+                    enabled = true,
+                    selectedDestinations = persistentSetOf(
+                        RECIPIENT_ROW_PREVIEW_PRIMARY_DESTINATION,
+                    ),
+                    shape = recipientSelectionContactRowShape(
+                        index = index,
+                        totalCount = items.size,
+                    ),
+                    loadingDestination = RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION,
+                )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactRowSingleDestinationStatesPreview() {
+    val phoneContactItem = previewRecipientSelectionSingleDestinationContactItem()
+    val emailContactItem = previewRecipientSelectionSingleEmailDestinationContactItem()
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewRecipientSelectionContactRow(
+                item = phoneContactItem,
+                selectedDestinations = persistentSetOf(),
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = phoneContactItem,
+                selectedDestinations = persistentSetOf(
+                    RECIPIENT_ROW_PREVIEW_PRIMARY_DESTINATION,
+                ),
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = emailContactItem,
+                selectedDestinations = persistentSetOf(),
+                loadingDestination = RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION,
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = emailContactItem,
+                enabled = false,
+                selectedDestinations = persistentSetOf(
+                    RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION,
+                ),
+                onDestinationLongClick = null,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactRowSyntheticPhoneStatesPreview() {
+    val syntheticPhoneItem = previewRecipientSelectionSyntheticPhoneItem()
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewRecipientSelectionContactRow(
+                item = syntheticPhoneItem,
+                selectedDestinations = persistentSetOf(),
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = syntheticPhoneItem,
+                selectedDestinations = persistentSetOf(
+                    RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION,
+                ),
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = syntheticPhoneItem,
+                selectedDestinations = persistentSetOf(
+                    RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION,
+                ),
+                loadingDestination = RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION,
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = syntheticPhoneItem,
+                enabled = false,
+                selectedDestinations = persistentSetOf(),
+                onDestinationLongClick = null,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactRowMultiDestinationWrapperPreview() {
+    val contactItem = previewRecipientSelectionMultiDestinationContactItem()
+    MessagingPreviewColumn {
+        Column(verticalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            PreviewRecipientSelectionContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf(),
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf(
+                    RECIPIENT_ROW_PREVIEW_SECONDARY_DESTINATION,
+                ),
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = contactItem,
+                selectedDestinations = persistentSetOf<String>()
+                    .add(RECIPIENT_ROW_PREVIEW_PRIMARY_DESTINATION)
+                    .add(RECIPIENT_ROW_PREVIEW_SECONDARY_DESTINATION)
+                    .add(RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION),
+                loadingDestination = RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactRowLongTextPreview() {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.width(width = 320.dp),
+            verticalArrangement = Arrangement.spacedBy(space = 12.dp),
+        ) {
+            PreviewRecipientSelectionContactRow(
+                item = previewRecipientSelectionLongSingleDestinationContactItem(),
+                selectedDestinations = persistentSetOf(
+                    RECIPIENT_ROW_PREVIEW_LONG_PHONE_DESTINATION,
+                ),
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = previewRecipientSelectionLongMultiDestinationContactItem(),
+                selectedDestinations = persistentSetOf(
+                    RECIPIENT_ROW_PREVIEW_LONG_EMAIL_DESTINATION,
+                ),
+            )
+
+            PreviewRecipientSelectionContactRow(
+                item = previewRecipientSelectionLongSyntheticPhoneItem(),
+                selectedDestinations = persistentSetOf(
+                    RECIPIENT_ROW_PREVIEW_LONG_SYNTHETIC_DESTINATION,
+                ),
+            )
+        }
+    }
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactRowPreviewSupport.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactRowPreviewSupport.kt
@@ -1,0 +1,266 @@
+package com.android.messaging.ui.conversation.recipientpicker.component
+
+import android.provider.ContactsContract.CommonDataKinds.Email
+import android.provider.ContactsContract.CommonDataKinds.Phone
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import com.android.messaging.ui.contact.model.ContactDestinationUiModel
+import com.android.messaging.ui.contact.model.ContactUiModel
+import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerListItem
+import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionRowDecorators
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentListOf
+
+internal const val RECIPIENT_ROW_PREVIEW_PRIMARY_DESTINATION = "+31622223333"
+internal const val RECIPIENT_ROW_PREVIEW_SECONDARY_DESTINATION = "+31644445555"
+internal const val RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION = "ada@example.com"
+internal const val RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION = "+31655550199"
+internal const val RECIPIENT_ROW_PREVIEW_LONG_PHONE_DESTINATION = "+1 415 555 0198 ext. 4827"
+internal const val RECIPIENT_ROW_PREVIEW_LONG_EMAIL_DESTINATION =
+    "alexandria.montgomery-washington@international-partnerships.example"
+internal const val RECIPIENT_ROW_PREVIEW_LONG_SYNTHETIC_DESTINATION = "+141555501984827"
+
+private const val PREVIEW_LONG_CONTACT_NAME =
+    "Alexandria Cassandra Montgomery-Washington from International Partnerships"
+private const val PREVIEW_LONG_SYNTHETIC_QUERY =
+    "+1 (415) 555-0198 extension 4827 for international routing desk"
+private const val PREVIEW_LONG_SYNTHETIC_SECONDARY_TEXT =
+    "Possible mobile number from pasted search text with country code and extension"
+
+@Composable
+internal fun PreviewRecipientSelectionContactRow(
+    item: RecipientPickerListItem,
+    selectedDestinations: ImmutableSet<String>,
+    enabled: Boolean = true,
+    shape: RoundedCornerShape = RoundedCornerShape(size = contactCornerRadius),
+    loadingDestination: String? = null,
+    onDestinationLongClick: ((destination: String) -> Unit)? = { _ -> },
+) {
+    RecipientSelectionContactRow(
+        item = item,
+        enabled = enabled,
+        selectedDestinations = selectedDestinations,
+        onDestinationClick = { _ -> },
+        shape = shape,
+        rowDecorators = previewRecipientSelectionRowDecorators(
+            loadingDestination = loadingDestination,
+        ),
+        onDestinationLongClick = onDestinationLongClick,
+    )
+}
+
+internal fun previewRecipientSelectionContactRowGroupedItems():
+    ImmutableList<RecipientPickerListItem> {
+    return persistentListOf<RecipientPickerListItem>()
+        .add(previewRecipientSelectionSingleDestinationContactItem())
+        .add(previewRecipientSelectionSyntheticPhoneItem())
+        .add(previewRecipientSelectionMultiDestinationContactItem())
+        .add(previewRecipientSelectionEmptyDestinationContactItem())
+}
+
+internal fun previewRecipientSelectionSingleDestinationContactItem(
+    contactId: Long = 1L,
+    destination: String = RECIPIENT_ROW_PREVIEW_PRIMARY_DESTINATION,
+    displayDestination: String = "+31 6 2222 3333",
+    kind: ContactDestinationUiModel.Kind = ContactDestinationUiModel.Kind.PHONE,
+    type: Int = Phone.TYPE_MOBILE,
+    displayName: String = "Ada Lovelace",
+): RecipientPickerListItem.Contact {
+    return RecipientPickerListItem.Contact(
+        contact = ContactUiModel(
+            id = contactId,
+            lookupKey = "preview-contact-$contactId",
+            displayName = displayName,
+            photoUri = null,
+            destinations = persistentListOf(
+                previewContactDestination(
+                    contactId = contactId,
+                    dataId = contactId * 10L,
+                    value = destination,
+                    displayValue = displayDestination,
+                    kind = kind,
+                    type = type,
+                    isPrimary = true,
+                    isSuperPrimary = true,
+                ),
+            ),
+        ),
+    )
+}
+
+internal fun previewRecipientSelectionSingleEmailDestinationContactItem():
+    RecipientPickerListItem.Contact {
+    return previewRecipientSelectionSingleDestinationContactItem(
+        contactId = 2L,
+        destination = RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION,
+        displayDestination = RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION,
+        kind = ContactDestinationUiModel.Kind.EMAIL,
+        type = Email.TYPE_HOME,
+    )
+}
+
+internal fun previewRecipientSelectionMultiDestinationContactItem():
+    RecipientPickerListItem.Contact {
+    return RecipientPickerListItem.Contact(
+        contact = ContactUiModel(
+            id = 3L,
+            lookupKey = "preview-contact-multi",
+            displayName = "Ada Lovelace",
+            photoUri = null,
+            destinations = persistentListOf<ContactDestinationUiModel>()
+                .add(
+                    previewContactDestination(
+                        contactId = 3L,
+                        dataId = 31L,
+                        value = RECIPIENT_ROW_PREVIEW_PRIMARY_DESTINATION,
+                        displayValue = "+31 6 2222 3333",
+                        kind = ContactDestinationUiModel.Kind.PHONE,
+                        type = Phone.TYPE_MOBILE,
+                        isPrimary = true,
+                        isSuperPrimary = true,
+                    ),
+                )
+                .add(
+                    previewContactDestination(
+                        contactId = 3L,
+                        dataId = 32L,
+                        value = RECIPIENT_ROW_PREVIEW_SECONDARY_DESTINATION,
+                        displayValue = "+31 6 4444 5555",
+                        kind = ContactDestinationUiModel.Kind.PHONE,
+                        type = Phone.TYPE_WORK,
+                    ),
+                )
+                .add(
+                    previewContactDestination(
+                        contactId = 3L,
+                        dataId = 33L,
+                        value = RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION,
+                        displayValue = RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION,
+                        kind = ContactDestinationUiModel.Kind.EMAIL,
+                        type = Email.TYPE_HOME,
+                    ),
+                ),
+        ),
+    )
+}
+
+internal fun previewRecipientSelectionLongSingleDestinationContactItem():
+    RecipientPickerListItem.Contact {
+    return previewRecipientSelectionSingleDestinationContactItem(
+        contactId = 4L,
+        destination = RECIPIENT_ROW_PREVIEW_LONG_PHONE_DESTINATION,
+        displayDestination = RECIPIENT_ROW_PREVIEW_LONG_PHONE_DESTINATION,
+        kind = ContactDestinationUiModel.Kind.PHONE,
+        type = Phone.TYPE_CUSTOM,
+        displayName = PREVIEW_LONG_CONTACT_NAME,
+    )
+}
+
+internal fun previewRecipientSelectionLongMultiDestinationContactItem():
+    RecipientPickerListItem.Contact {
+    return RecipientPickerListItem.Contact(
+        contact = ContactUiModel(
+            id = 5L,
+            lookupKey = "preview-contact-long-multi",
+            displayName = PREVIEW_LONG_CONTACT_NAME,
+            photoUri = null,
+            destinations = persistentListOf<ContactDestinationUiModel>()
+                .add(
+                    previewContactDestination(
+                        contactId = 5L,
+                        dataId = 51L,
+                        value = RECIPIENT_ROW_PREVIEW_LONG_PHONE_DESTINATION,
+                        displayValue = RECIPIENT_ROW_PREVIEW_LONG_PHONE_DESTINATION,
+                        kind = ContactDestinationUiModel.Kind.PHONE,
+                        type = Phone.TYPE_CUSTOM,
+                        customLabel = "Emergency escalation mobile",
+                    ),
+                )
+                .add(
+                    previewContactDestination(
+                        contactId = 5L,
+                        dataId = 52L,
+                        value = RECIPIENT_ROW_PREVIEW_LONG_EMAIL_DESTINATION,
+                        displayValue = RECIPIENT_ROW_PREVIEW_LONG_EMAIL_DESTINATION,
+                        kind = ContactDestinationUiModel.Kind.EMAIL,
+                        type = Email.TYPE_CUSTOM,
+                        customLabel = "International partnerships shared mailbox",
+                    ),
+                ),
+        ),
+    )
+}
+
+internal fun previewRecipientSelectionEmptyDestinationContactItem():
+    RecipientPickerListItem.Contact {
+    return RecipientPickerListItem.Contact(
+        contact = ContactUiModel(
+            id = 6L,
+            lookupKey = "preview-contact-empty",
+            displayName = "No Destination Contact",
+            photoUri = null,
+            destinations = persistentListOf(),
+        ),
+    )
+}
+
+internal fun previewRecipientSelectionSyntheticPhoneItem(): RecipientPickerListItem.SyntheticPhone {
+    return RecipientPickerListItem.SyntheticPhone(
+        id = "synthetic:${RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION}",
+        rawQuery = "+31 6 5555 0199",
+        destination = RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION,
+        normalizedDestination = RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION,
+        displayName = "+31 6 5555 0199",
+        secondaryText = "Mobile",
+    )
+}
+
+internal fun previewRecipientSelectionLongSyntheticPhoneItem():
+    RecipientPickerListItem.SyntheticPhone {
+    return RecipientPickerListItem.SyntheticPhone(
+        id = "synthetic:${RECIPIENT_ROW_PREVIEW_LONG_SYNTHETIC_DESTINATION}",
+        rawQuery = PREVIEW_LONG_SYNTHETIC_QUERY,
+        destination = RECIPIENT_ROW_PREVIEW_LONG_SYNTHETIC_DESTINATION,
+        normalizedDestination = RECIPIENT_ROW_PREVIEW_LONG_SYNTHETIC_DESTINATION,
+        displayName = PREVIEW_LONG_SYNTHETIC_QUERY,
+        secondaryText = PREVIEW_LONG_SYNTHETIC_SECONDARY_TEXT,
+    )
+}
+
+private fun previewRecipientSelectionRowDecorators(
+    loadingDestination: String?,
+): RecipientSelectionRowDecorators {
+    return RecipientSelectionRowDecorators(
+        recipientRowTestTag = { item -> item.id },
+        destinationRowTestTag = { item, destination -> "${item.id}:$destination" },
+        showRecipientTrailingIndicator = { _, destination ->
+            destination == loadingDestination
+        },
+    )
+}
+
+private fun previewContactDestination(
+    contactId: Long,
+    dataId: Long,
+    value: String,
+    displayValue: String,
+    kind: ContactDestinationUiModel.Kind,
+    type: Int,
+    customLabel: String? = null,
+    isPrimary: Boolean = false,
+    isSuperPrimary: Boolean = false,
+): ContactDestinationUiModel {
+    return ContactDestinationUiModel(
+        dataId = dataId,
+        contactId = contactId,
+        value = value,
+        normalizedValue = value,
+        displayValue = displayValue,
+        kind = kind,
+        type = type,
+        customLabel = customLabel,
+        isPrimary = isPrimary,
+        isSuperPrimary = isSuperPrimary,
+    )
+}

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactsContent.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactsContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -36,6 +37,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerListItem
@@ -43,6 +45,7 @@ import com.android.messaging.ui.conversation.recipientpicker.model.picker.Recipi
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.OnRecipientDestinationAction
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionContentUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionRowDecorators
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableSet
 
@@ -354,4 +357,111 @@ private fun RecipientSelectionEmptyState() {
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentLoadedPreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 420.dp),
+            uiState = previewRecipientSelectionContactsLoadedState(),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentLoadingPreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 260.dp),
+            uiState = previewRecipientSelectionContactsLoadingState(),
+            onRecipientDestinationLongClick = null,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentEmptyPreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 260.dp),
+            uiState = previewRecipientSelectionContactsEmptyState(),
+            onRecipientDestinationLongClick = null,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentLoadingMorePreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 420.dp),
+            uiState = previewRecipientSelectionContactsLoadingMoreState(),
+            loadingDestination = RECIPIENT_ROW_PREVIEW_EMAIL_DESTINATION,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentPrimaryActionDisabledPreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 420.dp),
+            uiState = previewRecipientSelectionContactsPrimaryActionDisabledState(),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentPrimaryActionLoadingPreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 420.dp),
+            uiState = previewRecipientSelectionContactsPrimaryActionLoadingState(),
+            loadingDestination = RECIPIENT_ROW_PREVIEW_SECONDARY_DESTINATION,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentNoPrimaryActionPreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 360.dp),
+            uiState = previewRecipientSelectionContactsNoPrimaryActionState(),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentTopListContentPreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 420.dp),
+            uiState = previewRecipientSelectionContactsTopContentState(),
+            topListContent = {
+                PreviewRecipientSelectionContactsTopListContent()
+            },
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContactsContentLongTextPreview() {
+    MessagingPreviewColumn {
+        PreviewRecipientSelectionContactsContent(
+            modifier = Modifier.height(height = 420.dp),
+            uiState = previewRecipientSelectionContactsLongTextState(),
+            loadingDestination = RECIPIENT_ROW_PREVIEW_LONG_EMAIL_DESTINATION,
+        )
+    }
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactsContentPreviewSupport.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContactsContentPreviewSupport.kt
@@ -1,0 +1,257 @@
+@file:Suppress("TooManyFunctions")
+
+package com.android.messaging.ui.conversation.recipientpicker.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerListItem
+import com.android.messaging.ui.conversation.recipientpicker.model.picker.RecipientPickerUiState
+import com.android.messaging.ui.conversation.recipientpicker.model.picker.SelectedRecipient
+import com.android.messaging.ui.conversation.recipientpicker.model.selection.OnRecipientDestinationAction
+import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionContentUiState
+import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionPrimaryActionUiState
+import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionRowDecorators
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+private const val PREVIEW_PRIMARY_ACTION_TEST_TAG = "preview-primary-action"
+private const val PREVIEW_TRAILING_INDICATOR_TEST_TAG = "preview-recipient-loading"
+
+@Composable
+internal fun PreviewRecipientSelectionContactsContent(
+    uiState: RecipientSelectionContentUiState,
+    modifier: Modifier = Modifier,
+    loadingDestination: String? = null,
+    onRecipientDestinationLongClick: OnRecipientDestinationAction? = { _, _ -> },
+    topListContent: (@Composable () -> Unit)? = null,
+) {
+    RecipientSelectionContactsContent(
+        modifier = modifier,
+        uiState = uiState,
+        rowDecorators = previewRecipientSelectionContactsRowDecorators(
+            loadingDestination = loadingDestination,
+        ),
+        onLoadMore = {},
+        onPrimaryActionClick = {},
+        onRecipientDestinationClick = { _, _ -> },
+        onRecipientDestinationLongClick = onRecipientDestinationLongClick,
+        topListContent = topListContent,
+    )
+}
+
+@Composable
+internal fun PreviewRecipientSelectionContactsTopListContent() {
+    RecipientSelectionSelectedRecipientChips(
+        modifier = Modifier.padding(bottom = 12.dp),
+        recipients = previewRecipientSelectionContactsSelectedRecipients(),
+        armedRecipientDestination = RECIPIENT_ROW_PREVIEW_PRIMARY_DESTINATION,
+        enabled = true,
+        onRecipientClick = { _ -> },
+    )
+}
+
+internal fun previewRecipientSelectionContactsLoadedState(): RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = previewRecipientSelectionContactsPickerState(
+            items = previewRecipientSelectionContactsDefaultItems(),
+        ),
+        primaryAction = previewRecipientSelectionPrimaryActionUiState(
+            isEnabled = true,
+        ),
+        selectedRecipients = previewRecipientSelectionContactsSelectedRecipients(),
+        isQueryEnabled = true,
+    )
+}
+
+internal fun previewRecipientSelectionContactsLoadingState(): RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = RecipientPickerUiState(
+            query = "Ada",
+            items = persistentListOf(),
+            canLoadMore = false,
+            hasContactsPermission = true,
+            isLoading = true,
+            isLoadingMore = false,
+        ),
+        primaryAction = null,
+        selectedRecipients = persistentListOf(),
+        isQueryEnabled = true,
+    )
+}
+
+internal fun previewRecipientSelectionContactsEmptyState(): RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = RecipientPickerUiState(
+            query = "No matches",
+            items = persistentListOf(),
+            canLoadMore = false,
+            hasContactsPermission = true,
+            isLoading = false,
+            isLoadingMore = false,
+        ),
+        primaryAction = null,
+        selectedRecipients = persistentListOf(),
+        isQueryEnabled = true,
+    )
+}
+
+internal fun previewRecipientSelectionContactsLoadingMoreState(): RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = previewRecipientSelectionContactsPickerState(
+            items = previewRecipientSelectionContactsDefaultItems(),
+            canLoadMore = true,
+            isLoadingMore = true,
+        ),
+        primaryAction = previewRecipientSelectionPrimaryActionUiState(
+            isEnabled = true,
+        ),
+        selectedRecipients = previewRecipientSelectionContactsSelectedRecipients(),
+        isQueryEnabled = true,
+    )
+}
+
+internal fun previewRecipientSelectionContactsPrimaryActionDisabledState():
+    RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = previewRecipientSelectionContactsPickerState(
+            items = previewRecipientSelectionContactsDefaultItems(),
+        ),
+        primaryAction = previewRecipientSelectionPrimaryActionUiState(
+            isEnabled = false,
+        ),
+        selectedRecipients = persistentListOf(),
+        isQueryEnabled = true,
+    )
+}
+
+internal fun previewRecipientSelectionContactsPrimaryActionLoadingState():
+    RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = previewRecipientSelectionContactsPickerState(
+            items = previewRecipientSelectionContactsDefaultItems(),
+        ),
+        primaryAction = previewRecipientSelectionPrimaryActionUiState(
+            isEnabled = true,
+            isLoading = true,
+        ),
+        selectedRecipients = previewRecipientSelectionContactsSelectedRecipients(),
+        isQueryEnabled = false,
+    )
+}
+
+internal fun previewRecipientSelectionContactsNoPrimaryActionState():
+    RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = previewRecipientSelectionContactsPickerState(
+            items = previewRecipientSelectionContactsDefaultItems(),
+        ),
+        primaryAction = null,
+        selectedRecipients = persistentListOf(),
+        isQueryEnabled = true,
+    )
+}
+
+internal fun previewRecipientSelectionContactsTopContentState(): RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = previewRecipientSelectionContactsPickerState(
+            items = previewRecipientSelectionContactsDefaultItems(),
+        ),
+        primaryAction = previewRecipientSelectionPrimaryActionUiState(
+            isEnabled = true,
+        ),
+        selectedRecipients = previewRecipientSelectionContactsSelectedRecipients(),
+        isQueryEnabled = true,
+    )
+}
+
+internal fun previewRecipientSelectionContactsLongTextState(): RecipientSelectionContentUiState {
+    return RecipientSelectionContentUiState(
+        picker = previewRecipientSelectionContactsPickerState(
+            items = persistentListOf<RecipientPickerListItem>()
+                .add(previewRecipientSelectionLongSingleDestinationContactItem())
+                .add(previewRecipientSelectionLongMultiDestinationContactItem())
+                .add(previewRecipientSelectionLongSyntheticPhoneItem()),
+        ),
+        primaryAction = previewRecipientSelectionPrimaryActionUiState(
+            isEnabled = true,
+        ),
+        selectedRecipients = persistentListOf(
+            SelectedRecipient(
+                destination = RECIPIENT_ROW_PREVIEW_LONG_PHONE_DESTINATION,
+                label = "Alexandria Cassandra Montgomery-Washington",
+                displayDestination = RECIPIENT_ROW_PREVIEW_LONG_PHONE_DESTINATION,
+                photoUri = null,
+            ),
+        ),
+        isQueryEnabled = true,
+    )
+}
+
+private fun previewRecipientSelectionContactsDefaultItems():
+    ImmutableList<RecipientPickerListItem> {
+    return persistentListOf<RecipientPickerListItem>()
+        .add(previewRecipientSelectionSingleDestinationContactItem())
+        .add(previewRecipientSelectionSyntheticPhoneItem())
+        .add(previewRecipientSelectionMultiDestinationContactItem())
+        .add(previewRecipientSelectionSingleEmailDestinationContactItem())
+}
+
+private fun previewRecipientSelectionContactsPickerState(
+    items: ImmutableList<RecipientPickerListItem>,
+    canLoadMore: Boolean = false,
+    isLoadingMore: Boolean = false,
+): RecipientPickerUiState {
+    return RecipientPickerUiState(
+        query = "Ada",
+        items = items,
+        canLoadMore = canLoadMore,
+        hasContactsPermission = true,
+        isLoading = false,
+        isLoadingMore = isLoadingMore,
+    )
+}
+
+private fun previewRecipientSelectionPrimaryActionUiState(
+    isEnabled: Boolean,
+    isLoading: Boolean = false,
+): RecipientSelectionPrimaryActionUiState {
+    return RecipientSelectionPrimaryActionUiState(
+        text = "Start chat",
+        isEnabled = isEnabled,
+        isLoading = isLoading,
+        testTag = PREVIEW_PRIMARY_ACTION_TEST_TAG,
+    )
+}
+
+private fun previewRecipientSelectionContactsSelectedRecipients():
+    ImmutableList<SelectedRecipient> {
+    return persistentListOf(
+        SelectedRecipient(
+            destination = RECIPIENT_ROW_PREVIEW_PRIMARY_DESTINATION,
+            label = "Ada Lovelace",
+            displayDestination = "+31 6 2222 3333",
+            photoUri = null,
+        ),
+        SelectedRecipient(
+            destination = RECIPIENT_ROW_PREVIEW_SYNTHETIC_DESTINATION,
+            label = "+31 6 5555 0199",
+            displayDestination = "Mobile",
+            photoUri = null,
+        ),
+    )
+}
+
+private fun previewRecipientSelectionContactsRowDecorators(
+    loadingDestination: String?,
+): RecipientSelectionRowDecorators {
+    return RecipientSelectionRowDecorators(
+        recipientRowTestTag = { item -> item.id },
+        destinationRowTestTag = { item, destination -> "${item.id}:$destination" },
+        showRecipientTrailingIndicator = { _, destination ->
+            destination == loadingDestination
+        },
+        trailingIndicatorTestTag = PREVIEW_TRAILING_INDICATOR_TEST_TAG,
+    )
+}

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContent.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionContent.kt
@@ -19,12 +19,16 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.conversation.preview.previewSimSelectorUiState
+import com.android.messaging.ui.conversation.recipientpicker.component.simselector.NewChatSimSelectorRow
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.SelectedRecipient
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.OnRecipientDestinationAction
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionContentUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionRowDecorators
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionStrings
+import com.android.messaging.ui.core.MessagingPreviewTheme
 
 @Composable
 internal fun RecipientSelectionContent(
@@ -235,4 +239,93 @@ private fun RecipientSelectionAutoFocusEffect(
             focusRequester.requestFocus()
         }
     }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContentLoadedPreview() {
+    PreviewRecipientSelectionContent(
+        uiState = previewRecipientSelectionContactsLoadedState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContentLoadingPreview() {
+    PreviewRecipientSelectionContent(
+        uiState = previewRecipientSelectionContactsLoadingState(),
+        onRecipientDestinationLongClick = null,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContentEmptyPreview() {
+    PreviewRecipientSelectionContent(
+        uiState = previewRecipientSelectionContactsEmptyState(),
+        onRecipientDestinationLongClick = null,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContentSimSelectorAndTopContentPreview() {
+    PreviewRecipientSelectionContent(
+        uiState = previewRecipientSelectionContactsTopContentState(),
+        simSelectorSlot = {
+            NewChatSimSelectorRow(
+                uiState = previewSimSelectorUiState(),
+                onSimSelected = { _ -> },
+            )
+        },
+        topListContent = {
+            PreviewRecipientSelectionContactsTopListContent()
+        },
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionContentPrimaryActionLoadingPreview() {
+    PreviewRecipientSelectionContent(
+        uiState = previewRecipientSelectionContactsPrimaryActionLoadingState(),
+    )
+}
+
+@Composable
+private fun PreviewRecipientSelectionContent(
+    uiState: RecipientSelectionContentUiState,
+    modifier: Modifier = Modifier.height(height = 560.dp),
+    onRecipientDestinationLongClick: OnRecipientDestinationAction? = { _, _ -> },
+    simSelectorSlot: (@Composable () -> Unit)? = null,
+    topListContent: (@Composable () -> Unit)? = null,
+) {
+    MessagingPreviewTheme {
+        RecipientSelectionContent(
+            modifier = modifier,
+            uiState = uiState,
+            strings = previewRecipientSelectionStrings(),
+            rowDecorators = previewRecipientSelectionContentRowDecorators(),
+            onRecipientDestinationClick = { _, _ -> },
+            onRecipientDestinationLongClick = onRecipientDestinationLongClick,
+            onSelectedRecipientClick = { _ -> },
+            onQueryChanged = { _ -> },
+            simSelectorSlot = simSelectorSlot,
+            topListContent = topListContent,
+        )
+    }
+}
+
+private fun previewRecipientSelectionStrings(): RecipientSelectionStrings {
+    return RecipientSelectionStrings(
+        queryPrefixText = "To",
+        queryPlaceholderText = "Name or phone number",
+    )
+}
+
+private fun previewRecipientSelectionContentRowDecorators(): RecipientSelectionRowDecorators {
+    return RecipientSelectionRowDecorators(
+        recipientRowTestTag = { item -> item.id },
+        destinationRowTestTag = { item, destination -> "${item.id}:$destination" },
+    )
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionPrimaryActionButton.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionPrimaryActionButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
@@ -25,7 +26,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.core.MessagingPreviewColumn
 
 @Composable
 internal fun RecipientSelectionPrimaryActionButton(
@@ -110,4 +113,31 @@ private fun recipientSelectionPrimaryActionContentTransform(): ContentTransform 
             targetScale = 0.9f,
         ),
     )
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionPrimaryActionButtonPreview() {
+    MessagingPreviewColumn {
+        Row(horizontalArrangement = Arrangement.spacedBy(space = 12.dp)) {
+            RecipientSelectionPrimaryActionButton(
+                enabled = true,
+                isLoading = false,
+                text = "Start chat",
+                onClick = {},
+            )
+            RecipientSelectionPrimaryActionButton(
+                enabled = false,
+                isLoading = false,
+                text = "Start chat",
+                onClick = {},
+            )
+            RecipientSelectionPrimaryActionButton(
+                enabled = true,
+                isLoading = true,
+                text = "Start chat",
+                onClick = {},
+            )
+        }
+    }
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionQueryCard.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionQueryCard.kt
@@ -1,5 +1,6 @@
 package com.android.messaging.ui.conversation.recipientpicker.component
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
@@ -27,7 +28,9 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.conversation.preview.previewRecipientSelectionContentUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.SelectedRecipient
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionContentUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionQueryCardUiState
@@ -35,6 +38,7 @@ import com.android.messaging.ui.conversation.recipientpicker.model.selection.Rec
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionQueryFieldUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionQueryTextUiState
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionStrings
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import kotlinx.collections.immutable.ImmutableList
 
 private val recipientSelectionInputRowMinHeight = 32.dp
@@ -328,4 +332,29 @@ private fun recipientSelectionMutationsEnabled(
     uiState: RecipientSelectionContentUiState,
 ): Boolean {
     return uiState.isQueryEnabled && uiState.primaryAction?.isLoading != true
+}
+
+@SuppressLint("RememberInComposition")
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionQueryCardPreview() {
+    val uiState = recipientSelectionQueryCardUiState(
+        uiState = previewRecipientSelectionContentUiState(),
+        strings = RecipientSelectionStrings(
+            queryPrefixText = "To",
+            queryPlaceholderText = "Name or phone number",
+        ),
+        armedRecipientDestination = "+31622223333",
+    )
+    MessagingPreviewColumn {
+        RecipientSelectionQueryCard(
+            uiState = uiState,
+            onQueryChanged = { _ -> },
+            onQueryFocused = {},
+            onSelectedRecipientClick = { _ -> },
+            onSelectedRecipientBackspace = { _ -> },
+            focusRequester = FocusRequester(),
+            simSelectorSlot = null,
+        )
+    }
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionQueryField.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionQueryField.kt
@@ -2,7 +2,10 @@
 
 package com.android.messaging.ui.conversation.recipientpicker.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
@@ -27,10 +30,16 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.conversation.RECIPIENT_SELECTION_QUERY_FIELD_TEST_TAG
+import com.android.messaging.ui.conversation.preview.previewSelectedRecipient
+import com.android.messaging.ui.conversation.recipientpicker.model.picker.SelectedRecipient
 import com.android.messaging.ui.conversation.recipientpicker.model.selection.RecipientSelectionQueryFieldUiState
+import com.android.messaging.ui.core.MessagingPreviewColumn
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun RecipientSelectionQueryField(
@@ -159,4 +168,133 @@ private fun recipientSelectionQueryPlaceholderTextStyle(
             MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Normal)
         }
     }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionQueryFieldPlaceholderPreview() {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(space = 16.dp),
+        ) {
+            RecipientSelectionQueryFieldPreviewItem(
+                label = "Empty, no selected recipients",
+                uiState = previewRecipientSelectionQueryFieldUiState(),
+            )
+            RecipientSelectionQueryFieldPreviewItem(
+                label = "Empty, selected recipient backspace target",
+                uiState = previewRecipientSelectionQueryFieldUiState(
+                    selectedRecipients = persistentListOf(previewSelectedRecipient()),
+                ),
+            )
+            RecipientSelectionQueryFieldPreviewItem(
+                label = "Disabled placeholder",
+                uiState = previewRecipientSelectionQueryFieldUiState(
+                    enabled = false,
+                    selectedRecipients = persistentListOf(previewSelectedRecipient()),
+                ),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionQueryFieldQueryPreview() {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(space = 16.dp),
+        ) {
+            RecipientSelectionQueryFieldPreviewItem(
+                label = "Short query",
+                uiState = previewRecipientSelectionQueryFieldUiState(query = "Ada"),
+            )
+            RecipientSelectionQueryFieldPreviewItem(
+                label = "Query after selected recipient",
+                uiState = previewRecipientSelectionQueryFieldUiState(
+                    query = "Grace Hopper",
+                    selectedRecipients = persistentListOf(previewSelectedRecipient()),
+                ),
+            )
+            RecipientSelectionQueryFieldPreviewItem(
+                label = "Disabled query",
+                uiState = previewRecipientSelectionQueryFieldUiState(
+                    query = "+31 6 2222 3333",
+                    enabled = false,
+                ),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionQueryFieldLongTextPreview() {
+    MessagingPreviewColumn {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(space = 16.dp),
+        ) {
+            RecipientSelectionQueryFieldPreviewItem(
+                label = "Long query constrained by available row width",
+                uiState = previewRecipientSelectionQueryFieldUiState(
+                    query = "averylongcontactsearchquery@example.messaging.preview",
+                    selectedRecipients = persistentListOf(previewSelectedRecipient()),
+                ),
+                maxWidth = 152.dp,
+            )
+            RecipientSelectionQueryFieldPreviewItem(
+                label = "Long localized placeholder constrained by row width",
+                uiState = previewRecipientSelectionQueryFieldUiState(
+                    placeholderText = "Name, phone number, email address, or group alias",
+                ),
+                maxWidth = 184.dp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecipientSelectionQueryFieldPreviewItem(
+    label: String,
+    uiState: RecipientSelectionQueryFieldUiState,
+    maxWidth: Dp? = null,
+) {
+    val editableText = recipientSelectionQueryFieldEditableText(uiState = uiState)
+    val textFieldState = remember(editableText) {
+        TextFieldState(initialText = editableText)
+    }
+    val focusRequester = remember { FocusRequester() }
+
+    Column(verticalArrangement = Arrangement.spacedBy(space = 4.dp)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        RecipientSelectionQueryField(
+            uiState = uiState,
+            state = textFieldState,
+            onQueryFocusChanged = { _ -> },
+            onLastSelectedRecipientRemove = {},
+            focusRequester = focusRequester,
+            maxWidth = maxWidth,
+        )
+    }
+}
+
+private fun previewRecipientSelectionQueryFieldUiState(
+    query: String = "",
+    enabled: Boolean = true,
+    placeholderText: String = "Name or phone number",
+    selectedRecipients: ImmutableList<SelectedRecipient> = persistentListOf(),
+): RecipientSelectionQueryFieldUiState {
+    return RecipientSelectionQueryFieldUiState(
+        query = query,
+        enabled = enabled,
+        placeholderText = placeholderText,
+        selectedRecipients = selectedRecipients,
+    )
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionSelectedRecipientChips.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/RecipientSelectionSelectedRecipientChips.kt
@@ -51,12 +51,16 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.android.messaging.R
+import com.android.messaging.ui.conversation.preview.previewSelectedRecipient
 import com.android.messaging.ui.conversation.recipientpicker.model.picker.SelectedRecipient
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 private val selectedRecipientAvatarSize = 24.dp
 private val selectedRecipientChipAvatarLabelSpacing = 4.dp
@@ -377,5 +381,26 @@ private fun selectedRecipientChipContentDescription(
                 recipient.label,
             )
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun RecipientSelectionSelectedRecipientChipsPreview() {
+    MessagingPreviewColumn {
+        RecipientSelectionSelectedRecipientChips(
+            recipients = persistentListOf(
+                previewSelectedRecipient(),
+                SelectedRecipient(
+                    destination = "+37255550101",
+                    label = "Grace Hopper",
+                    displayDestination = "+372 5555 0101",
+                    photoUri = null,
+                ),
+            ),
+            armedRecipientDestination = "+31622223333",
+            enabled = true,
+            onRecipientClick = { _ -> },
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/recipientpicker/component/simselector/NewChatSimSelector.kt
+++ b/src/com/android/messaging/ui/conversation/recipientpicker/component/simselector/NewChatSimSelector.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.data.subscription.model.Subscription
@@ -38,7 +39,9 @@ import com.android.messaging.ui.conversation.NEW_CHAT_SIM_SELECTOR_DROPDOWN_TEST
 import com.android.messaging.ui.conversation.composer.model.ConversationSimSelectorUiState
 import com.android.messaging.ui.conversation.composer.ui.ConversationSimAvatar
 import com.android.messaging.ui.conversation.newChatSimSelectorItemTestTag
+import com.android.messaging.ui.conversation.preview.previewSimSelectorUiState
 import com.android.messaging.ui.conversation.resolveDisplayName
+import com.android.messaging.ui.core.MessagingPreviewColumn
 import kotlinx.collections.immutable.ImmutableList
 
 private val ChipAvatarSize = 24.dp
@@ -234,5 +237,16 @@ private fun NewChatSimSelectorDropdownItemText(
                 overflow = TextOverflow.Ellipsis,
             )
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun NewChatSimSelectorRowPreview() {
+    MessagingPreviewColumn {
+        NewChatSimSelectorRow(
+            uiState = previewSimSelectorUiState(),
+            onSimSelected = { _ -> },
+        )
     }
 }

--- a/src/com/android/messaging/ui/conversation/screen/ConversationScreenContent.kt
+++ b/src/com/android/messaging/ui/conversation/screen/ConversationScreenContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.CONVERSATION_LOADING_INDICATOR_TEST_TAG
@@ -417,4 +418,85 @@ private fun rememberMessagesListState(
             firstVisibleItemScrollOffset = 0,
         )
     }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentLoadingPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentLoadingUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentSimLoadingPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentSimLoadingUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentEmptyPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentEmptyUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentDirectConversationPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentDirectUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentPresentPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentPresentUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentGroupRichPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentGroupRichUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentSelectionPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentSelectionUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentDateSeparatedPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentDateSeparatedUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentMmsDownloadPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentMmsDownloadUiState(),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationScreenContentNoSendSimPreview() {
+    ConversationScreenContentPreview(
+        uiState = previewConversationScreenContentNoSendSimUiState(),
+        conversationId = null,
+    )
 }

--- a/src/com/android/messaging/ui/conversation/screen/ConversationScreenContentPreviewSupport.kt
+++ b/src/com/android/messaging/ui/conversation/screen/ConversationScreenContentPreviewSupport.kt
@@ -1,0 +1,408 @@
+@file:Suppress("TooManyFunctions")
+
+package com.android.messaging.ui.conversation.screen
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.android.messaging.ui.conversation.composer.model.ConversationComposerUiState
+import com.android.messaging.ui.conversation.composer.model.ConversationSimSelectorUiState
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessagePartUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel.Status
+import com.android.messaging.ui.conversation.messages.model.message.ConversationMessagesUiState
+import com.android.messaging.ui.conversation.messages.model.message.MmsDownloadUiModel
+import com.android.messaging.ui.conversation.metadata.model.ConversationMetadataUiState
+import com.android.messaging.ui.conversation.preview.previewAudioPart
+import com.android.messaging.ui.conversation.preview.previewComposerUiState
+import com.android.messaging.ui.conversation.preview.previewFilePart
+import com.android.messaging.ui.conversation.preview.previewGroupMetadata
+import com.android.messaging.ui.conversation.preview.previewImagePart
+import com.android.messaging.ui.conversation.preview.previewIncomingMessage
+import com.android.messaging.ui.conversation.preview.previewMessagesUiState
+import com.android.messaging.ui.conversation.preview.previewMetadata
+import com.android.messaging.ui.conversation.preview.previewMmsDownloadUiModel
+import com.android.messaging.ui.conversation.preview.previewOutgoingMessage
+import com.android.messaging.ui.conversation.preview.previewSubscription
+import com.android.messaging.ui.conversation.preview.previewVCardPart
+import com.android.messaging.ui.conversation.preview.previewVideoPart
+import com.android.messaging.ui.conversation.screen.model.ConversationMessageSelectionAction
+import com.android.messaging.ui.conversation.screen.model.ConversationMessageSelectionUiState
+import com.android.messaging.ui.conversation.screen.model.ConversationScreenScaffoldUiState
+import com.android.messaging.ui.core.MessagingPreviewTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+
+private const val PREVIEW_SCREEN_CONTENT_NOW_MILLIS = 1_806_240_000_000L
+private const val PREVIEW_SCREEN_CONTENT_YESTERDAY_MILLIS =
+    PREVIEW_SCREEN_CONTENT_NOW_MILLIS - 86_400_000L
+private const val PREVIEW_SCREEN_CONTENT_OLDER_MILLIS =
+    PREVIEW_SCREEN_CONTENT_NOW_MILLIS - 172_800_000L
+private const val PREVIEW_SCREEN_CONTENT_LONG_TEXT = "This longer conversation message checks " +
+    "how the full content surface behaves when a row wraps over several lines, keeps metadata " +
+    "readable, and still leaves enough room for grouped incoming sender identity."
+private const val PREVIEW_SCREEN_CONTENT_OVERFLOW_TEXT =
+    "ConversationScreenContentPreviewTokenWithoutBreaksABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" +
+        "ConversationScreenContentPreviewTokenWithoutBreaksABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+@Composable
+internal fun ConversationScreenContentPreview(
+    uiState: ConversationScreenScaffoldUiState,
+    conversationId: String? = "conversation-1",
+) {
+    MessagingPreviewTheme {
+        ConversationScreenContent(
+            modifier = Modifier.fillMaxSize(),
+            conversationId = conversationId,
+            uiState = uiState,
+            snackbarHostState = SnackbarHostState(),
+            contentPadding = PaddingValues(),
+            pendingScrollPosition = null,
+            onPendingScrollPositionConsumed = {},
+            onAttachmentClick = { _, _ -> },
+            onExternalUriClick = {},
+            onMessageClick = {},
+            onMessageAvatarClick = {},
+            onMessageDownloadClick = {},
+            onMessageLongClick = {},
+            onMessageResendClick = {},
+            onSimSelectorClick = {},
+        )
+    }
+}
+
+internal fun previewConversationScreenContentLoadingUiState(): ConversationScreenScaffoldUiState {
+    return ConversationScreenScaffoldUiState()
+}
+
+internal fun previewConversationScreenContentSimLoadingUiState():
+    ConversationScreenScaffoldUiState {
+    return previewScreenContentUiState(
+        metadata = previewMetadata(),
+        messages = ConversationMessagesUiState.Present(
+            messages = previewScreenContentDirectMessages(),
+        ),
+        composer = previewComposerUiState().copy(
+            simSelector = ConversationSimSelectorUiState(isLoading = true),
+        ),
+    )
+}
+
+internal fun previewConversationScreenContentEmptyUiState(): ConversationScreenScaffoldUiState {
+    return previewScreenContentUiState(
+        metadata = previewMetadata(),
+        messages = ConversationMessagesUiState.Present(messages = persistentListOf()),
+        composer = previewSingleSimComposerUiState(),
+    )
+}
+
+internal fun previewConversationScreenContentDirectUiState(): ConversationScreenScaffoldUiState {
+    return previewScreenContentUiState(
+        metadata = previewMetadata(),
+        messages = ConversationMessagesUiState.Present(
+            messages = previewScreenContentDirectMessages(),
+        ),
+        composer = previewSingleSimComposerUiState(),
+    )
+}
+
+internal fun previewConversationScreenContentPresentUiState(): ConversationScreenScaffoldUiState {
+    return ConversationScreenScaffoldUiState(
+        metadata = previewGroupMetadata(),
+        messages = previewMessagesUiState(),
+        composer = previewComposerUiState(),
+    )
+}
+
+internal fun previewConversationScreenContentGroupRichUiState(): ConversationScreenScaffoldUiState {
+    return previewScreenContentUiState(
+        metadata = previewGroupMetadata(),
+        messages = ConversationMessagesUiState.Present(
+            messages = previewScreenContentRichMessages(),
+        ),
+        composer = previewComposerUiState(),
+    )
+}
+
+internal fun previewConversationScreenContentSelectionUiState(): ConversationScreenScaffoldUiState {
+    return previewScreenContentUiState(
+        metadata = previewGroupMetadata(),
+        messages = ConversationMessagesUiState.Present(
+            messages = previewScreenContentRichMessages(),
+        ),
+        composer = previewComposerUiState(),
+        selection = ConversationMessageSelectionUiState(
+            selectedMessageIds = persistentSetOf(
+                "screen-group-attachments",
+                "screen-group-failed",
+            ),
+            availableActions = persistentSetOf(
+                ConversationMessageSelectionAction.Copy,
+                ConversationMessageSelectionAction.Delete,
+                ConversationMessageSelectionAction.Forward,
+                ConversationMessageSelectionAction.SaveAttachment,
+            ),
+        ),
+    )
+}
+
+internal fun previewConversationScreenContentDateSeparatedUiState():
+    ConversationScreenScaffoldUiState {
+    return previewScreenContentUiState(
+        metadata = previewGroupMetadata(),
+        messages = ConversationMessagesUiState.Present(
+            messages = previewScreenContentDateSeparatedMessages(),
+        ),
+        composer = previewComposerUiState(),
+    )
+}
+
+internal fun previewConversationScreenContentMmsDownloadUiState():
+    ConversationScreenScaffoldUiState {
+    return previewScreenContentUiState(
+        metadata = previewGroupMetadata(),
+        messages = ConversationMessagesUiState.Present(
+            messages = previewScreenContentMmsDownloadMessages(),
+        ),
+        composer = previewSingleSimComposerUiState(),
+    )
+}
+
+internal fun previewConversationScreenContentNoSendSimUiState(): ConversationScreenScaffoldUiState {
+    return previewScreenContentUiState(
+        metadata = ConversationMetadataUiState.Unavailable,
+        messages = ConversationMessagesUiState.Present(
+            messages = previewScreenContentDirectMessages(),
+        ),
+        composer = previewDisabledComposerUiState(),
+    )
+}
+
+private fun previewScreenContentUiState(
+    metadata: ConversationMetadataUiState,
+    messages: ConversationMessagesUiState,
+    composer: ConversationComposerUiState,
+    selection: ConversationMessageSelectionUiState = ConversationMessageSelectionUiState(),
+): ConversationScreenScaffoldUiState {
+    return ConversationScreenScaffoldUiState(
+        metadata = metadata,
+        messages = messages,
+        composer = composer,
+        selection = selection,
+    )
+}
+
+private fun previewSingleSimComposerUiState(): ConversationComposerUiState {
+    val subscription = previewSubscription()
+    return previewComposerUiState(messageText = "").copy(
+        simSelector = ConversationSimSelectorUiState(
+            subscriptions = persistentListOf(subscription),
+            selectedSubscription = subscription,
+            isLoading = false,
+        ),
+        isSendEnabled = false,
+        shouldShowRecordAction = true,
+        hasWorkingDraft = false,
+    )
+}
+
+private fun previewDisabledComposerUiState(): ConversationComposerUiState {
+    return previewSingleSimComposerUiState().copy(
+        isMessageFieldEnabled = false,
+        isAttachmentActionEnabled = false,
+        isRecordActionEnabled = false,
+        shouldShowRecordAction = false,
+    )
+}
+
+private fun previewScreenContentDirectMessages(): ImmutableList<ConversationMessageUiModel> {
+    return persistentListOf(
+        previewIncomingMessage(
+            messageId = "screen-direct-address",
+            text = "The address is 1600 Amphitheatre Parkway. Meet near the main entrance.",
+        ).withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_OLDER_MILLIS),
+        previewOutgoingMessage(
+            messageId = "screen-direct-delivered",
+            text = "Got it. I am leaving in five minutes.",
+            status = Status.Outgoing.Delivered,
+        ).withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_YESTERDAY_MILLIS),
+        previewIncomingMessage(
+            messageId = "screen-direct-long",
+            text = PREVIEW_SCREEN_CONTENT_LONG_TEXT,
+        ).withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS),
+        previewOutgoingMessage(
+            messageId = "screen-direct-overflow",
+            text = PREVIEW_SCREEN_CONTENT_OVERFLOW_TEXT,
+            status = Status.Outgoing.Sending,
+        ).withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS),
+    )
+}
+
+private fun previewScreenContentRichMessages(): ImmutableList<ConversationMessageUiModel> {
+    return persistentListOf(
+        previewIncomingMessage(
+            messageId = "screen-group-start",
+            text = "I started a group thread so everyone has the same context.",
+        )
+            .withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_OLDER_MILLIS)
+            .withPreviewGrouping(canClusterWithNext = true),
+        previewIncomingMessage(
+            messageId = "screen-group-clustered",
+            text = "Second incoming row in the same participant cluster.",
+        )
+            .withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_OLDER_MILLIS)
+            .withPreviewGrouping(canClusterWithPrevious = true),
+        previewOutgoingMessage(
+            messageId = "screen-group-work-sim",
+            text = "Replying from the work SIM so the thread shows the SIM annotation.",
+            status = Status.Outgoing.Delivered,
+        )
+            .withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_YESTERDAY_MILLIS)
+            .withPreviewSelfParticipant(selfParticipantId = "self-2"),
+        previewIncomingMessage(
+            messageId = "screen-group-attachments",
+            text = "Photos, a file, a vCard, and the voice note are attached.",
+            parts = persistentListOf(
+                ConversationMessagePartUiModel.Text(
+                    text = "Photos, a file, a vCard, and the voice note are attached.",
+                ),
+                previewImagePart(text = "Front entrance"),
+                previewVideoPart(text = "Walkthrough clip"),
+                previewAudioPart(text = "Voice note"),
+                previewFilePart(text = "Briefing.pdf"),
+                previewVCardPart(),
+            ),
+            protocol = ConversationMessageUiModel.Protocol.MMS,
+            canSaveAttachments = true,
+        )
+            .copy(mmsSubject = "Site visit")
+            .withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS),
+        previewOutgoingMessage(
+            messageId = "screen-group-failed",
+            text = "This outgoing message failed and can be resent.",
+            status = Status.Outgoing.Failed,
+        ).withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS),
+    )
+}
+
+private fun previewScreenContentDateSeparatedMessages(): ImmutableList<ConversationMessageUiModel> {
+    return persistentListOf(
+        previewOutgoingMessage(
+            messageId = "screen-history-old-outgoing",
+            text = "Older outgoing message before a date boundary.",
+            status = Status.Outgoing.Complete,
+        ).withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_OLDER_MILLIS),
+        previewIncomingMessage(
+            messageId = "screen-history-yesterday-incoming",
+            text = "Yesterday's incoming message starts another separated group.",
+        ).withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_YESTERDAY_MILLIS),
+        previewIncomingMessage(
+            messageId = "screen-history-today-incoming",
+            text = "First message today with sender identity visible.",
+        )
+            .withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS)
+            .withPreviewGrouping(canClusterWithNext = true),
+        previewIncomingMessage(
+            messageId = "screen-history-today-cluster",
+            text = "Clustered continuation on the same day.",
+        )
+            .withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS)
+            .withPreviewGrouping(canClusterWithPrevious = true, canClusterWithNext = true),
+        previewIncomingMessage(
+            messageId = "screen-history-today-cluster-end",
+            text = "Final clustered continuation row.",
+        )
+            .withPreviewDisplayTime(displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS)
+            .withPreviewGrouping(canClusterWithPrevious = true),
+    )
+}
+
+private fun previewScreenContentMmsDownloadMessages(): ImmutableList<ConversationMessageUiModel> {
+    return persistentListOf(
+        previewMmsDownloadMessage(
+            messageId = "screen-mms-awaiting",
+            status = Status.Incoming.YetToManualDownload,
+            state = MmsDownloadUiModel.State.AwaitingManualDownload,
+            canDownloadMessage = true,
+            displayTimestamp = PREVIEW_SCREEN_CONTENT_OLDER_MILLIS,
+        ),
+        previewMmsDownloadMessage(
+            messageId = "screen-mms-manual-downloading",
+            status = Status.Incoming.ManualDownloading,
+            state = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+            displayTimestamp = PREVIEW_SCREEN_CONTENT_YESTERDAY_MILLIS,
+        ),
+        previewMmsDownloadMessage(
+            messageId = "screen-mms-auto-downloading",
+            status = Status.Incoming.AutoDownloading,
+            state = MmsDownloadUiModel.State.Downloading,
+            canDownloadMessage = false,
+            displayTimestamp = PREVIEW_SCREEN_CONTENT_YESTERDAY_MILLIS,
+        ),
+        previewMmsDownloadMessage(
+            messageId = "screen-mms-failed",
+            status = Status.Incoming.DownloadFailed,
+            state = MmsDownloadUiModel.State.DownloadFailed,
+            canDownloadMessage = true,
+            displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS,
+        ),
+        previewMmsDownloadMessage(
+            messageId = "screen-mms-expired",
+            status = Status.Incoming.ExpiredOrNotAvailable,
+            state = MmsDownloadUiModel.State.ExpiredOrUnavailable,
+            canDownloadMessage = false,
+            displayTimestamp = PREVIEW_SCREEN_CONTENT_NOW_MILLIS,
+        ),
+    )
+}
+
+private fun previewMmsDownloadMessage(
+    messageId: String,
+    status: Status.Incoming,
+    state: MmsDownloadUiModel.State,
+    canDownloadMessage: Boolean,
+    displayTimestamp: Long,
+): ConversationMessageUiModel {
+    return previewIncomingMessage(
+        messageId = messageId,
+        text = null,
+        status = status,
+        parts = persistentListOf(),
+        mmsDownload = previewMmsDownloadUiModel(state = state),
+        protocol = ConversationMessageUiModel.Protocol.MMS_PUSH_NOTIFICATION,
+        canDownloadMessage = canDownloadMessage,
+    ).withPreviewDisplayTime(displayTimestamp = displayTimestamp)
+}
+
+private fun ConversationMessageUiModel.withPreviewDisplayTime(
+    displayTimestamp: Long,
+): ConversationMessageUiModel {
+    return copy(
+        sentTimestamp = displayTimestamp,
+        receivedTimestamp = displayTimestamp,
+        displayTimestamp = displayTimestamp,
+    )
+}
+
+private fun ConversationMessageUiModel.withPreviewGrouping(
+    canClusterWithPrevious: Boolean = false,
+    canClusterWithNext: Boolean = false,
+): ConversationMessageUiModel {
+    return copy(
+        canClusterWithPrevious = canClusterWithPrevious,
+        canClusterWithNext = canClusterWithNext,
+    )
+}
+
+private fun ConversationMessageUiModel.withPreviewSelfParticipant(
+    selfParticipantId: String,
+): ConversationMessageUiModel {
+    return copy(
+        senderParticipantId = selfParticipantId,
+        selfParticipantId = selfParticipantId,
+    )
+}

--- a/src/com/android/messaging/ui/conversation/screen/ConversationSelectionTopAppBar.kt
+++ b/src/com/android/messaging/ui/conversation/screen/ConversationSelectionTopAppBar.kt
@@ -29,12 +29,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.android.messaging.R
 import com.android.messaging.ui.conversation.screen.model.ConversationMessageSelectionAction
 import com.android.messaging.ui.conversation.screen.model.ConversationMessageSelectionUiState
+import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toPersistentList
 
 private val messageSelectionActions = persistentListOf(
@@ -281,5 +284,46 @@ private fun selectionActionLabel(
         ConversationMessageSelectionAction.Share -> {
             stringResource(R.string.action_share)
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationSelectionTopAppBarSingleMessagePreview() {
+    MessagingPreviewTheme {
+        ConversationSelectionTopAppBar(
+            selection = ConversationMessageSelectionUiState(
+                selectedMessageIds = persistentSetOf("message-1"),
+                availableActions = persistentSetOf(
+                    ConversationMessageSelectionAction.Copy,
+                    ConversationMessageSelectionAction.Delete,
+                    ConversationMessageSelectionAction.Forward,
+                    ConversationMessageSelectionAction.Share,
+                ),
+            ),
+            onActionClick = { _ -> },
+            onDismissSelection = {},
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConversationSelectionTopAppBarMultiMessagePreview() {
+    MessagingPreviewTheme {
+        ConversationSelectionTopAppBar(
+            selection = ConversationMessageSelectionUiState(
+                selectedMessageIds = persistentSetOf("message-1", "message-2", "message-3"),
+                availableActions = persistentSetOf(
+                    ConversationMessageSelectionAction.Delete,
+                    ConversationMessageSelectionAction.SaveAttachment,
+                    ConversationMessageSelectionAction.Details,
+                    ConversationMessageSelectionAction.Resend,
+                    ConversationMessageSelectionAction.Download,
+                ),
+            ),
+            onActionClick = { _ -> },
+            onDismissSelection = {},
+        )
     }
 }

--- a/src/com/android/messaging/ui/core/Preview.kt
+++ b/src/com/android/messaging/ui/core/Preview.kt
@@ -1,0 +1,41 @@
+package com.android.messaging.ui.core
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun MessagingPreviewTheme(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    AppTheme {
+        Surface(
+            modifier = modifier,
+            color = MaterialTheme.colorScheme.background,
+            contentColor = MaterialTheme.colorScheme.onBackground,
+            content = content,
+        )
+    }
+}
+
+@Composable
+internal fun MessagingPreviewColumn(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    MessagingPreviewTheme(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = 16.dp),
+        ) {
+            content()
+        }
+    }
+}


### PR DESCRIPTION
Second (of 3) PR with Conversation screen rewritten with Kotlin and Compose.

This PR contains only `@Preview`-related changes. No changes in logic or production code.