### PR TITLE
Bound GIF dimensions before native transcoding

### DIFF
--- a/jni/GifTranscoder.cpp
+++ b/jni/GifTranscoder.cpp
@@ -39,6 +39,8 @@ static const ColorARGB TRANSPARENT = 0x0;
 
 #define MAX_COLOR_DISTANCE (255 * 255 * 255)
 
+static const int64_t kGifMaxArea = 4LL * 1024 * 1024;
+
 #define TAG "GifTranscoder.cpp"
 #define LOGD_ENABLED 0
 #if LOGD_ENABLED
@@ -119,6 +121,11 @@ bool GifTranscoder::resizeBoxFilter(GifFileType* gifIn, GifFileType* gifOut) {
 
     if (gifIn->SWidth < 0 || gifIn->SHeight < 0) {
         LOGE("Input GIF has invalid size: %d x %d", gifIn->SWidth, gifIn->SHeight);
+        return false;
+    }
+
+    if ((int64_t) gifIn->SWidth * gifIn->SHeight > kGifMaxArea) {
+        LOGE("Input GIF is too large: %d x %d", gifIn->SWidth, gifIn->SHeight);
         return false;
     }
 

--- a/src/com/android/messaging/util/GifTranscoder.java
+++ b/src/com/android/messaging/util/GifTranscoder.java
@@ -35,6 +35,8 @@ public class GifTranscoder {
 
     private static int MIN_HEIGHT = 100;
     private static int MIN_WIDTH = 100;
+    private static int MAX_HEIGHT = 2048;
+    private static int MAX_WIDTH = 2048;
 
     static {
         System.loadLibrary("giftranscode");
@@ -79,7 +81,8 @@ public class GifTranscoder {
         if (!isEnabled()) {
             return false;
         }
-        return width >= MIN_WIDTH && height >= MIN_HEIGHT;
+        return width >= MIN_WIDTH && height >= MIN_HEIGHT
+                && width <= MAX_WIDTH && height <= MAX_HEIGHT;
     }
 
     private static boolean isEnabled() {


### PR DESCRIPTION
The native GIF transcoder (`jni/GifTranscoder.cpp`) sizes its render buffers from the GIF's logical screen dimensions, computed as `int * int`:

```cpp
std::vector<GifByteType> srcBuffer(gifIn->SWidth * gifIn->SHeight);
std::unique_ptr<ColorARGB[]> renderBuffer(new ColorARGB[gifIn->SWidth * gifIn->SHeight]);
```

`SWidth`/`SHeight` come straight from the GIF (each up to 65535), and `canBeTranscoded()` only enforced a minimum size (>= 100x100), no maximum. A crafted GIF with large dimensions overflows the multiplication (65535*65535 wraps negative, becoming a huge `size_t`) or just requests an enormous allocation, so `std::vector`/`new[]` throws an uncaught C++ exception (`std::length_error`/`bad_alloc`) that propagates out of JNI and aborts the process (`SIGABRT`). Transcoding is enabled by default and runs on the send/forward path, so sending or forwarding such a GIF crashes Messaging.