### PR TITLE
Fix NULL dereference on GIF extension with no data blocks

### DIFF
--- a/jni/GifTranscoder.cpp
+++ b/jni/GifTranscoder.cpp
@@ -261,7 +261,7 @@ bool GifTranscoder::resizeBoxFilter(GifFileType* gifIn, GifFileType* gifOut) {
                     return false;
                 }
                 LOGD("Read extension block, code: %d", extCode);
-                if (extCode == GRAPHICS_EXT_FUNC_CODE) {
+                if (extCode == GRAPHICS_EXT_FUNC_CODE && ext != NULL) {
                     GraphicsControlBlock gcb;
                     if (DGifExtensionToGCB(ext[0], ext + 1, &gcb) == GIF_ERROR) {
                         LOGE("Could not interpret GCB extension");
@@ -295,7 +295,8 @@ bool GifTranscoder::resizeBoxFilter(GifFileType* gifIn, GifFileType* gifOut) {
                     LOGE("Could not write extension leader");
                     return false;
                 }
-                if (EGifPutExtensionBlock(gifOut, ext[0], ext + 1) == GIF_ERROR) {
+                if (ext != NULL &&
+                        EGifPutExtensionBlock(gifOut, ext[0], ext + 1) == GIF_ERROR) {
                     LOGE("Could not write extension block");
                     return false;
                 }


### PR DESCRIPTION
`DGifGetExtension` returns `GIF_OK` with a NULL extension pointer when an extension's first data block has size 0 (`dgif_lib.c` `DGifGetExtensionNext` sets `*Extension = NULL` for `Buf == 0`).
`GifTranscoder::resizeBoxFilter` then dereferences `ext[0]` without a NULL check, both in the `GRAPHICS_EXT_FUNC_CODE` handling (`DGifExtensionToGCB(ext[0], ext + 1, ...)`) and in `EGifPutExtensionBlock(gifOut, ext[0], ext + 1)`.
A crafted GIF with an empty extension (for example the bytes `21 F9 00`: extension introducer, graphics-control label, zero-size block) makes `ext == NULL`, so `ext[0]` reads address 0 and the native transcoder crashes with a NULL-pointer dereference (`SIGSEGV`).
The transcoder runs on the send/forward path (resizing a GIF for the MMS size limit), so sending or forwarding such a GIF could crash app.