### PR TITLE
Bound EXIF parser allocations to the APP1 segment size

### DIFF
--- a/app/src/test/java/com/android/messaging/util/exif/ExifParserOomTest.java
+++ b/app/src/test/java/com/android/messaging/util/exif/ExifParserOomTest.java
@@ -1,0 +1,99 @@
+package com.android.messaging.util.exif;
+
+import static org.junit.Assert.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class ExifParserOomTest {
+
+    @Test
+    public void readExif_tagValueSizeExceedingApp1Segment_isRejected() {
+        final ByteArrayOutputStream tiff = new ByteArrayOutputStream();
+        tiff.write('M');
+        tiff.write('M');
+        be16(tiff, 0x002A);
+        be32(tiff, 8);
+        be16(tiff, 1);
+        be16(tiff, 0x0111);
+        be16(tiff, 4);
+        be32(tiff, 0x0FFFFFFFL);
+        be32(tiff, 26);
+        be32(tiff, 0);
+        for (int i = 0; i < 8; i++) {
+            tiff.write(0);
+        }
+
+        assertThrows(IOException.class,
+                () -> new ExifInterface().readExif(wrapTiffInJpeg(tiff.toByteArray())));
+    }
+
+    @Test
+    public void readExif_ifd0OffsetExceedingApp1Segment_isRejected() {
+        final ByteArrayOutputStream tiff = new ByteArrayOutputStream();
+        tiff.write('M');
+        tiff.write('M');
+        be16(tiff, 0x002A);
+        be32(tiff, 0x7FFFFFFFL);
+
+        assertThrows(IOException.class,
+                () -> new ExifInterface().readExif(wrapTiffInJpeg(tiff.toByteArray())));
+    }
+
+    @Test
+    public void readExif_dataAboveIfd0TagOffsetOutOfBounds_isRejected() {
+        final ByteArrayOutputStream tiff = new ByteArrayOutputStream();
+        tiff.write('M');
+        tiff.write('M');
+        be16(tiff, 0x002A);
+        be32(tiff, 20);
+        for (int i = 0; i < 12; i++) {
+            tiff.write(0);
+        }
+        be16(tiff, 1);
+        be16(tiff, 0x9999);
+        be16(tiff, 7);
+        be32(tiff, 10);
+        be32(tiff, 0);
+        be32(tiff, 0);
+
+        assertThrows(IOException.class,
+                () -> new ExifInterface().readExif(wrapTiffInJpeg(tiff.toByteArray())));
+    }
+
+    private static byte[] wrapTiffInJpeg(final byte[] tiff) {
+        final ByteArrayOutputStream jpeg = new ByteArrayOutputStream();
+        jpeg.write(0xFF);
+        jpeg.write(0xD8);
+        jpeg.write(0xFF);
+        jpeg.write(0xE1);
+        be16(jpeg, 2 + 6 + tiff.length);
+        jpeg.write('E');
+        jpeg.write('x');
+        jpeg.write('i');
+        jpeg.write('f');
+        jpeg.write(0);
+        jpeg.write(0);
+        jpeg.write(tiff, 0, tiff.length);
+        jpeg.write(0xFF);
+        jpeg.write(0xD9);
+        return jpeg.toByteArray();
+    }
+
+    private static void be16(final ByteArrayOutputStream o, final int v) {
+        o.write((v >> 8) & 0xFF);
+        o.write(v & 0xFF);
+    }
+
+    private static void be32(final ByteArrayOutputStream o, final long v) {
+        o.write((int) ((v >> 24) & 0xFF));
+        o.write((int) ((v >> 16) & 0xFF));
+        o.write((int) ((v >> 8) & 0xFF));
+        o.write((int) (v & 0xFF));
+    }
+}

--- a/src/com/android/messaging/util/exif/ExifParser.java
+++ b/src/com/android/messaging/util/exif/ExifParser.java
@@ -217,7 +217,7 @@ public class ExifParser {
 
         parseTiffHeader();
         long offset = mTiffStream.readUnsignedInt();
-        if (offset > Integer.MAX_VALUE) {
+        if (offset > mApp1End) {
             throw new ExifInvalidFormatException("Invalid offset " + offset);
         }
         mIfd0Position = (int) offset;
@@ -495,6 +495,10 @@ public class ExifParser {
         return (int) mJpegSizeTag.getValueAt(0);
     }
 
+    protected int getApp1End() {
+        return mApp1End;
+    }
+
     private void skipTo(int offset) throws IOException {
         mTiffStream.skipTo(offset);
         while (!mCorrespondingEvent.isEmpty() && mCorrespondingEvent.firstKey() < offset) {
@@ -561,6 +565,12 @@ public class ExifParser {
             if (mDataAboveIfd0 != null
                     && offset < mIfd0Position
                     && dataFormat == ExifTag.TYPE_UNDEFINED) {
+                if (numOfComp < 0 || numOfComp > mApp1End) {
+                    throw new ExifInvalidFormatException("Invalid tag size " + numOfComp);
+                }
+                if (offset < DEFAULT_IFD0_OFFSET || offset + numOfComp > mIfd0Position) {
+                    throw new ExifInvalidFormatException("Invalid tag offset " + offset);
+                }
                 byte[] buf = new byte[(int) numOfComp];
                 System.arraycopy(mDataAboveIfd0, (int) offset - DEFAULT_IFD0_OFFSET,
                         buf, 0, (int) numOfComp);
@@ -647,6 +657,11 @@ public class ExifParser {
     }
 
     protected void readFullTagValue(ExifTag tag) throws IOException {
+        final long valueSize = (long) tag.getComponentCount()
+                * ExifTag.getElementSize(tag.getDataType());
+        if (valueSize < 0 || valueSize > mApp1End) {
+            throw new IOException("Invalid tag value size " + valueSize);
+        }
         // Some invalid images contains tags with wrong size, check it here
         short type = tag.getDataType();
         if (type == ExifTag.TYPE_ASCII || type == ExifTag.TYPE_UNDEFINED ||

--- a/src/com/android/messaging/util/exif/ExifReader.java
+++ b/src/com/android/messaging/util/exif/ExifReader.java
@@ -70,7 +70,12 @@ class ExifReader {
                     exifData.getIfdData(tag.getIfd()).setTag(tag);
                     break;
                 case ExifParser.EVENT_COMPRESSED_IMAGE:
-                    byte buf[] = new byte[parser.getCompressedImageSize()];
+                    int thumbnailSize = parser.getCompressedImageSize();
+                    if (thumbnailSize < 0 || thumbnailSize > parser.getApp1End()) {
+                        Log.w(TAG, "Invalid compressed thumbnail size");
+                        break;
+                    }
+                    byte buf[] = new byte[thumbnailSize];
                     if (buf.length == parser.read(buf)) {
                         exifData.setCompressedThumbnail(buf);
                     } else {
@@ -78,7 +83,12 @@ class ExifReader {
                     }
                     break;
                 case ExifParser.EVENT_UNCOMPRESSED_STRIP:
-                    buf = new byte[parser.getStripSize()];
+                    int stripSize = parser.getStripSize();
+                    if (stripSize < 0 || stripSize > parser.getApp1End()) {
+                        Log.w(TAG, "Invalid strip size");
+                        break;
+                    }
+                    buf = new byte[stripSize];
                     if (buf.length == parser.read(buf)) {
                         exifData.setStripBytes(parser.getStripIndex(), buf);
                     } else {


### PR DESCRIPTION
The app's EXIF parser (com.android.messaging.util.exif) sizes several heap allocations from attacker-controlled EXIF fields bounded only by Integer.MAX_VALUE: tag component counts (readFullTagValue), the IFD0 offset (mDataAboveIfd0), and the compressed-thumbnail and uncompressed-strip lengths (ExifReader). A crafted JPEG under ~80 bytes can declare a value of up to ~2GB, so new byte[...] / new long[...] throws OutOfMemoryError.

The parser is reached from ImageUtils.getOrientation (new ExifInterface().readExif(...)) when an image attachment is decoded for display. getOrientation catches only IOException and MediaResourceManager catches only Exception, so the OutOfMemoryError escapes and crashes the media-loading worker.

This bounds every such size by mApp1End, the length of the Exif APP1 segment (at most ~64KB), which valid EXIF data never exceeds. Oversized declarations are rejected with IOException before allocating, so the loader needs no catch (OutOfMemoryError).