### PR TITLE
Apply private-file check to shared text content URIs

### DIFF
--- a/src/com/android/messaging/ui/conversationlist/ShareIntentActivity.java
+++ b/src/com/android/messaging/ui/conversationlist/ShareIntentActivity.java
@@ -179,6 +179,10 @@ public class ShareIntentActivity extends BaseBugleActivity implements
         if (contentUri == null) {
             return null;
         }
+        if (FileUtil.isInPrivateDir(contentUri)) {
+            LogUtil.w(LogUtil.BUGLE_TAG, "Ignoring shared text from a private file URI");
+            return null;
+        }
         final ContentResolver resolver = Factory.get().getApplicationContext().getContentResolver();
         BufferedReader reader = null;
         try {


### PR DESCRIPTION
ShareIntentActivity's attachment path (addSharedPartToDraft) routes shared URIs through FileUtil.isInPrivateDir, which since f1b8f9a (Bug 275552292) resolves a content:// URI to its backing file and refuses the app's own private storage. The shared text/plain path, getTextStringFromContentUri, reads the supplied content:// URI through the app's ContentResolver with no such check, so the same private files remain reachable through the shared-text surface and their contents are read into the draft.

This applies the same FileUtil.isInPrivateDir guard at the top of getTextStringFromContentUri, covering both the SEND and SEND_MULTIPLE paths. A private-directory URI is skipped (returns null) instead of read; the attachment path is unchanged.