### PR TITLE
Raise Gradle heap to 4 GB to avoid flaky D8 dex-merge OOM in CI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 android.useAndroidX=true


### PR DESCRIPTION
The build workflow intermittently fails at :app:mergeExtDexDebug with "D8: java.lang.OutOfMemoryError: Java heap space". For example, the build for #135 failed this way (https://github.com/GrapheneOS/Messaging/actions/runs/26942391319/job/79486800054), while builds for other PRs touching comparable code passed, so it is not a code-level failure.

D8 dex merging runs in-process in the Gradle JVM (NoIsolation worker), so it draws from org.gradle.jvmargs, currently capped at -Xmx2048m. That is marginal for merging this app's dependency dex, which is why the same code passes on some runs and OOMs on others.

ubuntu-latest runners have ~16 GB of RAM, so this raises the cap to 4096m. Verified locally that the Gradle JVM then runs with a 4096 MB max heap.