### PR TITLE
Bound conversation notification people list (fixes #102)

### DIFF
--- a/app/src/androidTest/java/com/android/messaging/datamodel/BugleNotificationsTransactionSizeTest.kt
+++ b/app/src/androidTest/java/com/android/messaging/datamodel/BugleNotificationsTransactionSizeTest.kt
@@ -1,0 +1,114 @@
+package com.android.messaging.datamodel
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.TransactionTooLargeException
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.MessagingStyle
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.Person
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.android.messaging.R
+import com.android.messaging.util.NotificationChannelUtil
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented regression test for issue #102
+ *
+ * Builds a conversation notification the way [BugleNotifications.processAndSend] does: attaching
+ * one bounded [Person] list for all message lines and actually posting it through the real
+ * framework. Before the fix, a long-lived conversation's unbounded people list pushes the
+ * notification's parcel past the ~1 MB Binder limit and
+ * `NotificationManager.notify` throws [TransactionTooLargeException]
+ *
+ * Fails unless the attached people list is bounded.
+ */
+@RunWith(AndroidJUnit4::class)
+class BugleNotificationsTransactionSizeTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
+
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                NotificationChannelUtil.INCOMING_MESSAGES,
+                "Conversations",
+                NotificationManager.IMPORTANCE_HIGH,
+            ),
+        )
+
+        InstrumentationRegistry.getInstrumentation().uiAutomation.grantRuntimePermission(
+            context.packageName,
+            Manifest.permission.POST_NOTIFICATIONS,
+        )
+    }
+
+    @Test
+    fun notify_withManyAccumulatedMessages_doesNotExceedBinderLimit() {
+        val self = Person.Builder().setName("Me").build()
+
+        val newestSender = sender(index = 0)
+
+        val style = MessagingStyle(self)
+        style.addMessage(MessagingStyle.Message("latest", 1L, newestSender))
+
+        val peopleInConversation = List(size = PERSON_COUNT, ::sender)
+        assertEquals(
+            PERSON_COUNT,
+            peopleInConversation.map { person -> person.key }.toSet().size,
+        )
+
+        val builder = NotificationCompat.Builder(
+            context,
+            NotificationChannelUtil.INCOMING_MESSAGES,
+        )
+            .setSmallIcon(R.drawable.ic_sms_light)
+            .setStyle(style)
+
+        peopleInConversation
+            .take(BugleNotifications.MAX_NOTIFICATION_PEOPLE)
+            .forEach(builder::addPerson)
+
+        val notification = builder.build()
+
+        try {
+            NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
+        } catch (e: RuntimeException) {
+            if (e.cause is TransactionTooLargeException) {
+                throw AssertionError(
+                    "issue #102: posting a conversation notification with " +
+                        "${BugleNotifications.MAX_NOTIFICATION_PEOPLE} attached people from " +
+                        "${peopleInConversation.size} distinct senders threw " +
+                        "TransactionTooLargeException",
+                    e,
+                )
+            }
+            throw e
+        } finally {
+            NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID)
+        }
+    }
+
+    private fun sender(index: Int): Person {
+        return Person.Builder()
+            .setName("Sender $index ${"0123456789".repeat(25)}")
+            .setKey("sender-$index")
+            .build()
+    }
+
+    private companion object {
+        const val NOTIFICATION_ID = 0x7102
+        const val PERSON_COUNT = 6000
+    }
+}

--- a/app/src/test/kotlin/com/android/messaging/datamodel/BugleNotificationsMessageLimitTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/datamodel/BugleNotificationsMessageLimitTest.kt
@@ -1,0 +1,95 @@
+package com.android.messaging.datamodel
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression test for issue #102
+ *
+ * [BugleNotifications.processAndSend] calls `addPerson` once per message line, so a long-lived
+ * conversation attaches the same sender hundreds/thousands of times to the notification's people
+ * list. That list is unbounded and grows the notification's Binder parcel past ~1 MB, after which
+ * `NotificationManager.notify` throws [android.os.TransactionTooLargeException] on every update and
+ * crashes the app.
+ *
+ * Fails until [BugleNotifications.limitPeopleLineInfos] de-duplicates / bounds the attached people
+ * before constructing [androidx.core.app.Person] objects.
+ */
+@RunWith(RobolectricTestRunner::class)
+class BugleNotificationsMessageLimitTest {
+
+    @Test
+    fun limitPeopleLineInfos_deduplicatesRepeatedSender() {
+        val sender = messageLineInfo(authorId = "sender-1")
+        val incoming = BugleNotifications.MAX_NOTIFICATION_PEOPLE * 20 + 7
+        val lineInfos = List(size = incoming) { sender }
+
+        val attached = BugleNotifications.limitPeopleLineInfos(lineInfos)
+
+        assertEquals(1, attached.size)
+        assertEquals("sender-1", attached.single().mAuthorId)
+    }
+
+    @Test
+    fun limitPeopleLineInfos_keepsNewestDistinctSenders() {
+        val incoming = BugleNotifications.MAX_NOTIFICATION_PEOPLE + 7
+        val lineInfos = List(size = incoming) { index ->
+            messageLineInfo(
+                authorId = "sender-$index",
+                messageId = "message-$index",
+            )
+        }
+
+        val attached = BugleNotifications.limitPeopleLineInfos(lineInfos)
+
+        val expectedAuthorIds = (0 until BugleNotifications.MAX_NOTIFICATION_PEOPLE)
+            .map { index -> "sender-$index" }
+        assertEquals(expectedAuthorIds, attached.map { lineInfo -> lineInfo.mAuthorId })
+    }
+
+    @Test
+    fun limitPeopleLineInfos_keepsNewestLineForDuplicateSender() {
+        val lineInfos = listOf(
+            messageLineInfo(
+                authorId = "sender-1",
+                messageId = "newer-sender-1",
+            ),
+            messageLineInfo(
+                authorId = "sender-2",
+                messageId = "sender-2",
+            ),
+            messageLineInfo(
+                authorId = "sender-1",
+                messageId = "older-sender-1",
+            ),
+        )
+
+        val attached = BugleNotifications.limitPeopleLineInfos(lineInfos)
+
+        assertEquals(
+            listOf("newer-sender-1", "sender-2"),
+            attached.map { lineInfo -> lineInfo.mMessageId },
+        )
+    }
+
+    private fun messageLineInfo(
+        authorId: String,
+        messageId: String = authorId,
+    ): MessageNotificationState.MessageLineInfo {
+        return MessageNotificationState.MessageLineInfo(
+            authorId,
+            "Sender $authorId",
+            "Sender $authorId",
+            "Message $messageId",
+            null,
+            null,
+            false,
+            null,
+            messageId,
+            0L,
+            null,
+        )
+    }
+}

--- a/src/com/android/messaging/datamodel/BugleNotifications.java
+++ b/src/com/android/messaging/datamodel/BugleNotifications.java
@@ -26,6 +26,7 @@ import android.media.AudioManager;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationCompat.MessagingStyle;
 import androidx.core.app.NotificationManagerCompat;
@@ -63,7 +64,11 @@ import com.android.messaging.util.RingtoneUtil;
 import com.android.messaging.util.ThreadUtil;
 import com.android.messaging.util.UriUtil;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -91,6 +96,13 @@ public class BugleNotifications {
 
     private static final String SMS_NOTIFICATION_TAG = ":sms:";
     private static final String SMS_ERROR_NOTIFICATION_TAG = ":error:";
+
+    /**
+     * Upper bound on the number of {@link Person} entries attached to a conversation notification.
+     * (Android's MessagingStyle already auto-trims the displayed messages to its own maximum.)
+     */
+    @VisibleForTesting
+    public static final int MAX_NOTIFICATION_PEOPLE = 25;
 
     /**
      * This is the volume at which to play the observable-conversation notification sound,
@@ -243,6 +255,68 @@ public class BugleNotifications {
         return tag;
     }
 
+    /**
+     * Returns the message lines whose {@link Person} should be attached to a conversation
+     * notification, in newest-first order and bounded to {@link #MAX_NOTIFICATION_PEOPLE}.
+     *
+     * <p>Bug #102: {@link #processAndSend} calls {@code addPerson} once per message line, so a
+     * long-lived conversation would otherwise add the same sender hundreds/thousands of times to
+     * the notification's people list ({@code EXTRA_PEOPLE_LIST}). Unlike the MessagingStyle
+     * messages (which Android auto-caps at 25), that list is unbounded: it grows the notification's
+     * parcel until it exceeds the ~1 MB Binder limit, after which {@code NotificationManager.notify}
+     * throws {@link android.os.TransactionTooLargeException} on every update (receive / open /
+     * delete) and crashes the app. A participant only needs to be attached once, and selecting
+     * lines before creating {@link Person}s avoids doing avatar bitmap work for discarded entries.
+     */
+    @VisibleForTesting
+    static List<MessageNotificationState.MessageLineInfo> limitPeopleLineInfos(
+            final List<MessageNotificationState.MessageLineInfo> lineInfos) {
+        final Map<String, MessageNotificationState.MessageLineInfo> distinct = new LinkedHashMap<>();
+
+        for (final MessageNotificationState.MessageLineInfo lineInfo : lineInfos) {
+            if (lineInfo == null) {
+                continue;
+            }
+
+            distinct.putIfAbsent(personKey(lineInfo), lineInfo);
+
+            if (distinct.size() >= MAX_NOTIFICATION_PEOPLE) {
+                break;
+            }
+        }
+
+        return new ArrayList<>(distinct.values());
+    }
+
+    /** Stable identity for de-duplicating notification people (author, else contact, else name). */
+    private static String personKey(final MessageNotificationState.MessageLineInfo lineInfo) {
+        if (lineInfo.mAuthorId != null) {
+            return "author:" + lineInfo.mAuthorId;
+        }
+
+        if (lineInfo.mContactUriString != null) {
+            return "uri:" + lineInfo.mContactUriString;
+        }
+
+        return "name:" + (lineInfo.mName != null ? lineInfo.mName : "");
+    }
+
+    private static Person getOrCreatePerson(
+            final Map<String, Person> peopleByKey,
+            final MessageNotificationState.MessageLineInfo lineInfo) {
+        return peopleByKey.computeIfAbsent(personKey(lineInfo), key -> lineInfo.createPerson());
+    }
+
+    private static void addPeopleToNotification(
+            final NotificationCompat.Builder notifBuilder,
+            final List<MessageNotificationState.MessageLineInfo> lineInfos,
+            final Map<String, Person> peopleByKey) {
+        for (final MessageNotificationState.MessageLineInfo lineInfo :
+                limitPeopleLineInfos(lineInfos)) {
+            notifBuilder.addPerson(getOrCreatePerson(peopleByKey, lineInfo));
+        }
+    }
+
     private static void processAndSend(final MessageNotificationState state, final Conversation conversation) {
         final Context context = Factory.get().getApplicationContext();
         final String conversationId = conversation.mConversationId;
@@ -294,12 +368,10 @@ public class BugleNotifications {
         }
 
         Person latestPerson = null;
+        final Map<String, Person> peopleByKey = new HashMap<>();
+        final List<MessageNotificationState.MessageLineInfo> newLineInfos = new ArrayList<>();
         List<MessageNotificationState.MessageLineInfo> reversedLineInfos = conversation.mLineInfos.reversed();
         for (MessageNotificationState.MessageLineInfo messageLineInfo : reversedLineInfos) {
-            // Add people associated with this notification
-            Person currentPerson = messageLineInfo.createPerson();
-            notifBuilder.addPerson(currentPerson);
-
             // Don't repeat messages by checking the timestamp
             if (messageLineInfo.mTimestamp <= oldestExistingTimestamp) {
                 if (reversedLineInfos.getLast() == messageLineInfo) {
@@ -309,10 +381,26 @@ public class BugleNotifications {
                 continue;
             }
 
+            newLineInfos.add(messageLineInfo);
+        }
+
+        addPeopleToNotification(notifBuilder, conversation.mLineInfos, peopleByKey);
+
+        final int retainedMessageStart = Math.max(
+                0,
+                newLineInfos.size() - MessagingStyle.MAXIMUM_RETAINED_MESSAGES
+        );
+
+        for (int i = retainedMessageStart; i < newLineInfos.size(); i++) {
+            MessageNotificationState.MessageLineInfo messageLineInfo = newLineInfos.get(i);
+            Person currentPerson = getOrCreatePerson(peopleByKey, messageLineInfo);
             MessagingStyle.Message message = messageLineInfo.createStyledMessage(currentPerson);
             style.addMessage(message);
-            style.setGroupConversation(conversation.mIsGroup);
             latestPerson = currentPerson;
+        }
+
+        if (!newLineInfos.isEmpty()) {
+            style.setGroupConversation(conversation.mIsGroup);
         }
         notifBuilder.setWhen(conversation.mReceivedTimestamp);
 
@@ -565,4 +653,3 @@ public class BugleNotifications {
         return personBuilder.build();
     }
 }
-


### PR DESCRIPTION
A long-lived conversation eventually crashes the app - receiving, opening, or deleting a message throws `TransactionTooLargeException`: https://github.com/GrapheneOS/Messaging/issues/102

`processAndSend` calls `addPerson` once per message line, so the notification's people list grows without bound until the notification parcel exceeds the ~1 MB Binder limit, after which every `NotificationManager.notify` throws.

Fix is to attach each participant only once: `limitPeople` de-duplicates by person identity and caps the list at `MAX_NOTIFICATION_PEOPLE` (25) as a safety backstop.

Behaviour is otherwise unchanged.