### PR TITLE
Fix MMS download notification sync race

### DIFF
--- a/app/src/test/java/com/android/messaging/FactoryTestAccess.java
+++ b/app/src/test/java/com/android/messaging/FactoryTestAccess.java
@@ -1,0 +1,18 @@
+package com.android.messaging;
+
+public final class FactoryTestAccess {
+    private FactoryTestAccess() {
+    }
+
+    public static void install(final Factory factory) {
+        Factory.sRegistered = false;
+        Factory.sInitialized = false;
+        Factory.setInstance(factory);
+    }
+
+    public static void reset() {
+        Factory.sRegistered = false;
+        Factory.sInitialized = false;
+        Factory.setInstance(null);
+    }
+}

--- a/app/src/test/java/com/android/messaging/datamodel/ActionSyncTestDataModel.java
+++ b/app/src/test/java/com/android/messaging/datamodel/ActionSyncTestDataModel.java
@@ -1,0 +1,128 @@
+package com.android.messaging.datamodel;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.net.Uri;
+
+import com.android.messaging.datamodel.action.ActionService;
+import com.android.messaging.datamodel.action.BackgroundWorker;
+import com.android.messaging.datamodel.data.BlockedParticipantsData;
+import com.android.messaging.datamodel.data.ContactListItemData;
+import com.android.messaging.datamodel.data.ContactPickerData;
+import com.android.messaging.datamodel.data.ConversationData;
+import com.android.messaging.datamodel.data.ConversationListData;
+import com.android.messaging.datamodel.data.DraftMessageData;
+import com.android.messaging.datamodel.data.GalleryGridItemData;
+import com.android.messaging.datamodel.data.LaunchConversationData;
+import com.android.messaging.datamodel.data.MediaPickerData;
+import com.android.messaging.datamodel.data.MessagePartData;
+import com.android.messaging.datamodel.data.VCardContactItemData;
+import com.android.messaging.util.Assert;
+
+public class ActionSyncTestDataModel extends DataModel {
+    private DatabaseWrapper mDatabase;
+    private final SyncManager mSyncManager = new SyncManager();
+    private final ActionService mActionService = new ActionService();
+    private final BackgroundWorker mBackgroundWorker = new BackgroundWorker();
+
+    public void setDatabase(final DatabaseWrapper database) {
+        mDatabase = database;
+    }
+
+    @Override
+    public ConversationListData createConversationListData(final Context context,
+            final ConversationListData.ConversationListDataListener listener,
+            final boolean archivedMode) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConversationData createConversationData(final Context context,
+            final ConversationData.ConversationDataListener listener,
+            final String conversationId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ContactListItemData createContactListItemData() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ContactPickerData createContactPickerData(final Context context,
+            final ContactPickerData.ContactPickerDataListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MediaPickerData createMediaPickerData(final Context context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GalleryGridItemData createGalleryGridItemData() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LaunchConversationData createLaunchConversationData(
+            final LaunchConversationData.LaunchConversationDataListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VCardContactItemData createVCardContactItemData(final Context context,
+            final MessagePartData data) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VCardContactItemData createVCardContactItemData(final Context context,
+            final Uri vCardUri) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BlockedParticipantsData createBlockedParticipantsData(final Context context,
+            final BlockedParticipantsData.BlockedParticipantsDataListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DraftMessageData createDraftMessageData(final String conversationId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ActionService getActionService() {
+        return mActionService;
+    }
+
+    @Override
+    public BackgroundWorker getBackgroundWorkerForActionService() {
+        return mBackgroundWorker;
+    }
+
+    @Override
+    public DatabaseWrapper getDatabase() {
+        Assert.isNotMainThread();
+        return mDatabase;
+    }
+
+    @Override
+    public void onActivityResume() {
+    }
+
+    @Override
+    void onCreateTables(final SQLiteDatabase db) {
+    }
+
+    @Override
+    public void onApplicationCreated() {
+    }
+
+    @Override
+    public SyncManager getSyncManager() {
+        return mSyncManager;
+    }
+}

--- a/app/src/test/kotlin/com/android/messaging/datamodel/ActionSyncTestDatabase.kt
+++ b/app/src/test/kotlin/com/android/messaging/datamodel/ActionSyncTestDatabase.kt
@@ -1,0 +1,11 @@
+package com.android.messaging.datamodel
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+
+internal fun createInMemoryActionSyncTestDatabase(context: Context): DatabaseWrapper {
+    val sqliteDatabase = SQLiteDatabase.create(null)
+    DatabaseHelper.rebuildTables(sqliteDatabase)
+
+    return DatabaseWrapper(context, sqliteDatabase)
+}

--- a/app/src/test/kotlin/com/android/messaging/datamodel/action/SyncMessagesActionMmsReplacementRaceTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/datamodel/action/SyncMessagesActionMmsReplacementRaceTest.kt
@@ -1,0 +1,1411 @@
+package com.android.messaging.datamodel.action
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.UriMatcher
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.provider.BaseColumns
+import android.provider.Telephony.Mms
+import android.provider.Telephony.Sms
+import androidx.collection.LongSparseArray
+import androidx.core.content.contentValuesOf
+import com.android.messaging.BugleApplication
+import com.android.messaging.Factory
+import com.android.messaging.FactoryTestAccess
+import com.android.messaging.datamodel.ActionSyncTestDataModel
+import com.android.messaging.datamodel.DataModel
+import com.android.messaging.datamodel.DatabaseHelper
+import com.android.messaging.datamodel.DatabaseHelper.ConversationColumns
+import com.android.messaging.datamodel.DatabaseHelper.ConversationParticipantsColumns
+import com.android.messaging.datamodel.DatabaseHelper.MessageColumns
+import com.android.messaging.datamodel.DatabaseHelper.ParticipantColumns
+import com.android.messaging.datamodel.DatabaseWrapper
+import com.android.messaging.datamodel.action.mms.IsMmsNotificationDownloadCountSynchronized
+import com.android.messaging.datamodel.action.mms.mmsNotificationDownloadStatuses
+import com.android.messaging.datamodel.createInMemoryActionSyncTestDatabase
+import com.android.messaging.datamodel.data.MessageData
+import com.android.messaging.datamodel.data.ParticipantData
+import com.android.messaging.mmslib.pdu.PduHeaders
+import com.android.messaging.sms.DatabaseMessages
+import com.android.messaging.util.BugleGservices
+import com.android.messaging.util.BuglePrefs
+import com.android.messaging.util.PhoneUtils
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowContentResolver
+
+/**
+ * Regression test for #144.
+ *
+ * MMS download replacement temporarily removes the telephony M-Notification.ind row and replaces it
+ * with the final downloaded MMS. Sync must not mistake that transient missing remote row for a real
+ * user deletion while the local message is still in a download/notification state.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = SyncMessagesActionMmsReplacementRaceTestApplication::class)
+class SyncMessagesActionMmsReplacementRaceTest {
+
+    private lateinit var context: Context
+    private lateinit var dataModel: ActionSyncTestDataModel
+    private lateinit var database: DatabaseWrapper
+    private lateinit var telephonyProvider: FakeTelephonyProvider
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication().applicationContext
+        dataModel = ActionSyncTestDataModel()
+
+        FactoryTestAccess.install(testFactory(context = context, dataModel = dataModel))
+
+        database = createInMemoryActionSyncTestDatabase(context)
+        dataModel.setDatabase(database)
+
+        seedSelfParticipant()
+        deleteSyntheticRows()
+
+        telephonyProvider = FakeTelephonyProvider()
+        ShadowContentResolver.registerProviderInternal("sms", telephonyProvider)
+        ShadowContentResolver.registerProviderInternal("mms", telephonyProvider)
+        ShadowContentResolver.registerProviderInternal("mms-sms", telephonyProvider)
+    }
+
+    @After
+    fun tearDown() {
+        ShadowContentResolver.reset()
+        if (::database.isInitialized) {
+            deleteSyntheticRows()
+        }
+
+        FactoryTestAccess.reset()
+    }
+
+    @Test
+    fun syncDoesNotDeleteIncomingMmsDownloadReplacementStatesWhenRemoteRowIsTemporarilyMissing() {
+        mmsNotificationDownloadStatuses.forEachIndexed { index, status ->
+            seedIncomingMmsPushNotification(
+                id = TEST_ID_BASE + index,
+                status = status,
+                timestampMillis = TEST_TIMESTAMP_MILLIS - index,
+            )
+        }
+
+        runSyncBatch()
+
+        mmsNotificationDownloadStatuses.forEachIndexed { index, status ->
+            assertMessageCount(
+                id = TEST_ID_BASE + index,
+                expectedCount = 1,
+                failureMessage = "MMS download/replacement status $status was deleted",
+            )
+        }
+    }
+
+    @Test
+    fun syncReplacesIncomingMmsNotificationWithDownloadedMmsMatchingTransactionId() {
+        val notificationId = TEST_ID_BASE
+        val downloadedMmsId = TEST_ID_BASE + protectedStatusCount
+
+        seedIncomingMmsPushNotification(
+            id = notificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        telephonyProvider.addMmsRow(
+            id = downloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            threadId = notificationId,
+            transactionId = transactionIdFor(id = notificationId),
+        )
+
+        runSyncBatch()
+
+        val message = requireNotNull(readMessage(id = notificationId))
+        assertEquals(MessageData.PROTOCOL_MMS, message.getProtocol())
+        assertEquals(MessageData.BUGLE_STATUS_INCOMING_COMPLETE, message.getStatus())
+        assertEquals("content://mms/$downloadedMmsId", message.getSmsMessageUri().toString())
+        assertMessageCount(id = downloadedMmsId, expectedCount = 0)
+    }
+
+    @Test
+    fun syncReplacesIncomingMmsNotificationWhenDownloadedMmsMovesConversationWithSameSender() {
+        val notificationId = TEST_ID_BASE
+        val downloadedMmsId = TEST_ID_BASE + protectedStatusCount
+        val downloadedThreadId = TEST_ID_BASE + 100L
+        val originalConversationId = (notificationId + CONVERSATION_ID_OFFSET).toString()
+
+        seedIncomingMmsPushNotification(
+            id = notificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        telephonyProvider.setThreadRecipient(
+            threadId = downloadedThreadId,
+            recipientId = notificationId,
+        )
+        telephonyProvider.addMmsRow(
+            id = downloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            threadId = downloadedThreadId,
+            transactionId = transactionIdFor(id = notificationId),
+        )
+
+        runSyncBatch()
+
+        val message = requireNotNull(readMessage(id = notificationId))
+        assertEquals(MessageData.PROTOCOL_MMS, message.getProtocol())
+        assertEquals(MessageData.BUGLE_STATUS_INCOMING_COMPLETE, message.getStatus())
+        assertEquals("content://mms/$downloadedMmsId", message.getSmsMessageUri().toString())
+        assertFalse(message.getConversationId() == originalConversationId)
+        assertEquals(0, countConversations(id = originalConversationId))
+        assertEquals(1, countConversations(id = message.getConversationId()))
+    }
+
+    @Test
+    fun syncReplacesIncomingMmsNotificationWhenDownloadedMmsSenderDiffers() {
+        val notificationId = TEST_ID_BASE
+        val downloadedMmsId = TEST_ID_BASE + protectedStatusCount
+        val downloadedThreadId = TEST_ID_BASE + 100L
+
+        seedIncomingMmsPushNotification(
+            id = notificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        telephonyProvider.addMmsRow(
+            id = downloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            threadId = downloadedThreadId,
+            transactionId = transactionIdFor(id = notificationId),
+        )
+
+        runSyncBatch()
+
+        val message = requireNotNull(readMessage(id = notificationId))
+        assertEquals(MessageData.PROTOCOL_MMS, message.getProtocol())
+        assertEquals(MessageData.BUGLE_STATUS_INCOMING_COMPLETE, message.getStatus())
+        assertEquals("content://mms/$downloadedMmsId", message.getSmsMessageUri().toString())
+        assertMessageCount(id = downloadedMmsId, expectedCount = 0)
+        assertEquals(1, countMessagesByUri(messageUri = "content://mms/$downloadedMmsId"))
+    }
+
+    @Test
+    fun syncKeepsDownloadedMmsWhenReplacingExpiredIncomingMmsNotification() {
+        val notificationId = TEST_ID_BASE
+        val downloadedMmsId = TEST_ID_BASE + protectedStatusCount
+
+        seedIncomingMmsPushNotification(
+            id = notificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            mmsExpiryMillis = EXPIRED_MMS_EXPIRY_MILLIS,
+        )
+        telephonyProvider.addMmsRow(
+            id = downloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            threadId = notificationId,
+            transactionId = transactionIdFor(id = notificationId),
+        )
+
+        runSyncBatch()
+
+        val message = requireNotNull(readMessage(id = notificationId))
+        assertEquals(MessageData.PROTOCOL_MMS, message.getProtocol())
+        assertEquals(MessageData.BUGLE_STATUS_INCOMING_COMPLETE, message.getStatus())
+        assertEquals("content://mms/$downloadedMmsId", message.getSmsMessageUri().toString())
+        assertEquals(1, countMessagesByUri(messageUri = "content://mms/$downloadedMmsId"))
+    }
+
+    @Test
+    fun syncDoesNotReplaceIncomingMmsNotificationWhenDownloadedMmsTransactionIdIsMissing() {
+        val emptyTransactionNotificationId = TEST_ID_BASE
+        val nullTransactionNotificationId = TEST_ID_BASE + 1L
+        val emptyTransactionDownloadedMmsId = TEST_ID_BASE + protectedStatusCount
+        val nullTransactionDownloadedMmsId = emptyTransactionDownloadedMmsId + 1L
+
+        seedIncomingMmsPushNotification(
+            id = emptyTransactionNotificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        seedIncomingMmsPushNotification(
+            id = nullTransactionNotificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS - 1L,
+        )
+        telephonyProvider.addMmsRow(
+            id = emptyTransactionDownloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            threadId = emptyTransactionNotificationId,
+            transactionId = "",
+        )
+        telephonyProvider.addMmsRow(
+            id = nullTransactionDownloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS - 1L,
+            threadId = nullTransactionNotificationId,
+            transactionId = null,
+        )
+
+        runSyncBatch()
+
+        assertIncomingMmsNotificationStillDownloading(id = emptyTransactionNotificationId)
+        assertIncomingMmsNotificationStillDownloading(id = nullTransactionNotificationId)
+        assertEquals(
+            1,
+            countMessagesByUri(messageUri = "content://mms/$emptyTransactionDownloadedMmsId"),
+        )
+        assertEquals(
+            1,
+            countMessagesByUri(messageUri = "content://mms/$nullTransactionDownloadedMmsId"),
+        )
+    }
+
+    @Test
+    fun syncDoesNotReplaceIncomingMmsNotificationWithDifferentSelfParticipant() {
+        val notificationId = TEST_ID_BASE
+        val downloadedMmsId = TEST_ID_BASE + protectedStatusCount
+
+        seedSelfParticipant(
+            id = OTHER_SELF_PARTICIPANT_DB_ID,
+            subId = OTHER_SELF_PARTICIPANT_SUB_ID,
+        )
+        seedIncomingMmsPushNotification(
+            id = notificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            selfParticipantId = OTHER_SELF_PARTICIPANT_DB_ID,
+        )
+        telephonyProvider.addMmsRow(
+            id = downloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            threadId = notificationId,
+            transactionId = transactionIdFor(id = notificationId),
+        )
+
+        runSyncBatch()
+
+        assertIncomingMmsNotificationStillDownloading(id = notificationId)
+        assertEquals(1, countMessagesByUri(messageUri = "content://mms/$downloadedMmsId"))
+    }
+
+    @Test
+    fun syncCountTreatsTemporarilyMissingDownloadingMmsNotificationAsSynchronized() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+
+        assertTrue(isSynchronized())
+    }
+
+    @Test
+    fun syncCountTreatsUnknownExpiryMissingDownloadingMmsNotificationAsSynchronized() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            mmsExpiryMillis = UNKNOWN_MMS_EXPIRY_MILLIS,
+        )
+
+        assertTrue(isSynchronized())
+    }
+
+    @Test
+    fun syncCountDoesNotIgnoreDownloadingMmsNotificationWithUnparseableRemoteUri() {
+        seedLocalMessage(
+            id = TEST_ID_BASE,
+            protocol = MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            messageUri = "content://mms/not-a-row-id",
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+
+        assertFalse(
+            isMmsNotificationDownloadCountSynchronized(
+                localCount = 1,
+                remoteCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun syncCountFallsBackToRawCountsWhenRemoteMmsIdBatchQueryFails() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        telephonyProvider.addMmsRow(
+            id = TEST_ID_BASE,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            messageType = PduHeaders.MESSAGE_TYPE_NOTIFICATION_IND,
+        )
+        telephonyProvider.failRemoteMmsIdBatchQuery = true
+
+        assertTrue(
+            isMmsNotificationDownloadCountSynchronized(
+                localCount = 1,
+                remoteCount = 1,
+            ),
+        )
+        assertEquals(1, telephonyProvider.remoteMmsIdBatchQueryCount)
+    }
+
+    @Test
+    fun syncCountDoesNotForceResyncWhenRemoteReplacementQueryFails() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        telephonyProvider.failRemoteMmsReplacementQuery = true
+
+        assertTrue(
+            isMmsNotificationDownloadCountSynchronized(
+                localCount = 1,
+                remoteCount = 0,
+            ),
+        )
+        assertEquals(1, telephonyProvider.remoteMmsReplacementQueryCount)
+    }
+
+    @Test
+    fun syncCountChecksExistingRemoteNotificationRowsInOneBatchQuery() {
+        mmsNotificationDownloadStatuses.forEachIndexed { index, status ->
+            val id = TEST_ID_BASE + index
+            seedIncomingMmsPushNotification(
+                id = id,
+                status = status,
+                timestampMillis = TEST_TIMESTAMP_MILLIS - index,
+            )
+            telephonyProvider.addMmsRow(
+                id = id,
+                timestampMillis = TEST_TIMESTAMP_MILLIS - index,
+                messageType = PduHeaders.MESSAGE_TYPE_NOTIFICATION_IND,
+            )
+        }
+
+        assertTrue(isSynchronized())
+
+        assertEquals(1, telephonyProvider.remoteMmsIdBatchQueryCount)
+    }
+
+    @Test
+    fun syncCountTreatsDownloadedMmsReplacingLocalNotificationAsUnsynchronized() {
+        val notificationId = TEST_ID_BASE
+        val downloadedMmsId = TEST_ID_BASE + protectedStatusCount
+
+        seedIncomingMmsPushNotification(
+            id = notificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        telephonyProvider.addMmsRow(
+            id = downloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            threadId = notificationId,
+            transactionId = transactionIdFor(id = notificationId),
+        )
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncCountTreatsDownloadedMmsReplacingExpiredLocalNotificationAsUnsynchronized() {
+        val notificationId = TEST_ID_BASE
+        val downloadedMmsId = TEST_ID_BASE + protectedStatusCount
+
+        seedIncomingMmsPushNotification(
+            id = notificationId,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            mmsExpiryMillis = EXPIRED_MMS_EXPIRY_MILLIS,
+        )
+        telephonyProvider.addMmsRow(
+            id = downloadedMmsId,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            threadId = notificationId,
+            transactionId = transactionIdFor(id = notificationId),
+        )
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncCountTreatsExpiredMissingDownloadingMmsNotificationAsUnsynchronized() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            mmsExpiryMillis = EXPIRED_MMS_EXPIRY_MILLIS,
+        )
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncCountTreatsTerminalIncomingMmsNotificationStatusesAsUnsynchronized() {
+        terminalMmsNotificationStatuses.forEachIndexed { index, status ->
+            seedIncomingMmsPushNotification(
+                id = TEST_ID_BASE + index,
+                status = status,
+                timestampMillis = TEST_TIMESTAMP_MILLIS - index,
+            )
+        }
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncCountTreatsCompletedLocalMmsMissingRemoteRowAsUnsynchronized() {
+        seedLocalMessage(
+            id = TEST_ID_BASE,
+            protocol = MessageData.PROTOCOL_MMS,
+            status = MessageData.BUGLE_STATUS_INCOMING_COMPLETE,
+            messageUri = "content://mms/$TEST_ID_BASE",
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncCountTreatsRemoteOnlyMmsNotificationAsUnsynchronized() {
+        telephonyProvider.addMmsRow(
+            id = TEST_ID_BASE,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            messageType = PduHeaders.MESSAGE_TYPE_NOTIFICATION_IND,
+        )
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncCountDoesNotHideUnrelatedMismatchWhenIgnoringMissingDownloadingNotification() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        seedLocalMessage(
+            id = TEST_ID_BASE + 1L,
+            protocol = MessageData.PROTOCOL_SMS,
+            status = MessageData.BUGLE_STATUS_INCOMING_COMPLETE,
+            messageUri = "content://sms/${TEST_ID_BASE + 1L}",
+            timestampMillis = TEST_TIMESTAMP_MILLIS - 1L,
+        )
+        telephonyProvider.addMmsRow(
+            id = TEST_ID_BASE + 2L,
+            timestampMillis = TEST_TIMESTAMP_MILLIS - 2L,
+        )
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncCountDoesNotHideUnrelatedMmsMismatchWhenIgnoringMissingDownloadingNotification() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        seedLocalMessage(
+            id = TEST_ID_BASE + 1L,
+            protocol = MessageData.PROTOCOL_MMS,
+            status = MessageData.BUGLE_STATUS_INCOMING_COMPLETE,
+            messageUri = "content://mms/${TEST_ID_BASE + 1L}",
+            timestampMillis = TEST_TIMESTAMP_MILLIS - 1_000L,
+        )
+        telephonyProvider.addMmsRow(
+            id = TEST_ID_BASE + 2L,
+            timestampMillis = TEST_TIMESTAMP_MILLIS - 2_000L,
+        )
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncCountTreatsMatchingRemainingMessagesWithMissingDownloadingNotificationAsSynchronized() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        seedLocalMessage(
+            id = TEST_ID_BASE + 1L,
+            protocol = MessageData.PROTOCOL_MMS,
+            status = MessageData.BUGLE_STATUS_INCOMING_COMPLETE,
+            messageUri = "content://mms/${TEST_ID_BASE + 1L}",
+            timestampMillis = TEST_TIMESTAMP_MILLIS - 1_000L,
+        )
+        telephonyProvider.addMmsRow(
+            id = TEST_ID_BASE + 1L,
+            timestampMillis = TEST_TIMESTAMP_MILLIS - 1_000L,
+        )
+
+        assertTrue(isSynchronized())
+    }
+
+    @Test
+    fun syncKeepsMmsWhenMatchingRemoteRowStillExists() {
+        seedLocalMessage(
+            id = TEST_ID_BASE,
+            protocol = MessageData.PROTOCOL_MMS,
+            status = MessageData.BUGLE_STATUS_INCOMING_COMPLETE,
+            messageUri = "content://mms/$TEST_ID_BASE",
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        telephonyProvider.addMmsRow(id = TEST_ID_BASE, timestampMillis = TEST_TIMESTAMP_MILLIS)
+
+        runSyncBatch()
+
+        assertMessageCount(id = TEST_ID_BASE, expectedCount = 1)
+    }
+
+    @Test
+    fun syncKeepsIncomingMmsNotificationWhenMatchingRemoteNotificationRowStillExists() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+        telephonyProvider.addMmsRow(
+            id = TEST_ID_BASE,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            messageType = PduHeaders.MESSAGE_TYPE_NOTIFICATION_IND,
+        )
+
+        runSyncBatch()
+
+        assertIncomingMmsNotificationStillDownloading(id = TEST_ID_BASE)
+        assertEquals(1, countMessagesByUri(messageUri = "content://mms/$TEST_ID_BASE"))
+    }
+
+    @Test
+    fun syncDeletesYetToManualDownloadMmsNotificationWhenRemoteRowIsMissing() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_YET_TO_MANUAL_DOWNLOAD,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+
+        runSyncBatch()
+
+        assertMessageCount(id = TEST_ID_BASE, expectedCount = 0)
+    }
+
+    @Test
+    fun syncCountTreatsYetToManualDownloadMmsNotificationMissingRemoteRowAsUnsynchronized() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_YET_TO_MANUAL_DOWNLOAD,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+
+        assertFalse(isSynchronized())
+    }
+
+    @Test
+    fun syncDeletesExpiredIncomingMmsNotificationWhenRemoteRowIsMissing() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            mmsExpiryMillis = EXPIRED_MMS_EXPIRY_MILLIS,
+        )
+
+        runSyncBatch()
+
+        assertMessageCount(id = TEST_ID_BASE, expectedCount = 0)
+    }
+
+    @Test
+    fun syncDeletesTerminalIncomingMmsNotificationStatusesWhenRemoteRowIsMissing() {
+        terminalMmsNotificationStatuses.forEachIndexed { index, status ->
+            seedIncomingMmsPushNotification(
+                id = TEST_ID_BASE + index,
+                status = status,
+                timestampMillis = TEST_TIMESTAMP_MILLIS - index,
+            )
+        }
+
+        runSyncBatch()
+
+        terminalMmsNotificationStatuses.forEachIndexed { index, status ->
+            assertMessageCount(
+                id = TEST_ID_BASE + index,
+                expectedCount = 0,
+                failureMessage = "Terminal MMS notification status $status was not deleted",
+            )
+        }
+    }
+
+    @Test
+    fun syncKeepsUnknownExpiryIncomingMmsNotificationWhenRemoteRowIsMissing() {
+        seedIncomingMmsPushNotification(
+            id = TEST_ID_BASE,
+            status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+            mmsExpiryMillis = UNKNOWN_MMS_EXPIRY_MILLIS,
+        )
+
+        runSyncBatch()
+
+        val message = requireNotNull(readMessage(id = TEST_ID_BASE))
+        assertEquals(MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION, message.getProtocol())
+        assertEquals(MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING, message.getStatus())
+    }
+
+    @Test
+    fun syncStillDeletesCompletedMmsWhenRemoteRowIsMissing() {
+        seedLocalMessage(
+            id = TEST_ID_BASE,
+            protocol = MessageData.PROTOCOL_MMS,
+            status = MessageData.BUGLE_STATUS_INCOMING_COMPLETE,
+            messageUri = "content://mms/$TEST_ID_BASE",
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+
+        runSyncBatch()
+
+        assertMessageCount(id = TEST_ID_BASE, expectedCount = 0)
+    }
+
+    @Test
+    fun syncStillDeletesSmsWhenRemoteRowIsMissing() {
+        seedLocalMessage(
+            id = TEST_ID_BASE,
+            protocol = MessageData.PROTOCOL_SMS,
+            status = MessageData.BUGLE_STATUS_INCOMING_COMPLETE,
+            messageUri = "content://sms/$TEST_ID_BASE",
+            timestampMillis = TEST_TIMESTAMP_MILLIS,
+        )
+
+        runSyncBatch()
+
+        assertMessageCount(id = TEST_ID_BASE, expectedCount = 0)
+    }
+
+    private fun testFactory(context: Context, dataModel: DataModel): Factory {
+        val gServices = mockk<BugleGservices>(relaxed = true)
+        every { gServices.getLong(any(), any()) } answers { secondArg() }
+        every { gServices.getInt(any(), any()) } answers { secondArg() }
+        every { gServices.getBoolean(any(), any()) } answers { secondArg() }
+        every { gServices.getString(any(), any()) } answers { secondArg() }
+        every { gServices.getFloat(any(), any()) } answers { secondArg() }
+
+        val prefs = mockk<BuglePrefs>(relaxed = true)
+        every { prefs.getSharedPreferencesName() } returns BuglePrefs.SHARED_PREFERENCES_NAME
+        every { prefs.getInt(any(), any()) } answers { secondArg() }
+        every { prefs.getLong(any(), any()) } answers { secondArg() }
+        every { prefs.getBoolean(any(), any()) } answers { secondArg() }
+        every { prefs.getString(any(), any()) } answers { secondArg() }
+
+        val phoneUtils = mockk<PhoneUtils>(relaxed = true)
+        every { phoneUtils.getSubIdFromTelephony(any(), any()) } answers {
+            firstArg<Cursor>().getInt(secondArg<Int>())
+        }
+        every { phoneUtils.getCanonicalBySimLocale(any()) } answers { firstArg() }
+        every { phoneUtils.formatForDisplay(any()) } answers { firstArg() }
+
+        return mockk<Factory>(relaxed = true).also { factory ->
+            every { factory.getApplicationContext() } returns context
+            every { factory.getDataModel() } returns dataModel
+            every { factory.getBugleGservices() } returns gServices
+            every { factory.getApplicationPrefs() } returns prefs
+            every { factory.getSubscriptionPrefs(any()) } returns prefs
+            every { factory.getWidgetPrefs() } returns prefs
+            every { factory.getPhoneUtils(any()) } returns phoneUtils
+        }
+    }
+
+    private fun runSyncBatch() {
+        var failure: Throwable? = null
+        val thread = Thread(
+            {
+                try {
+                    runSyncBatchOnWorker()
+                } catch (throwable: Throwable) {
+                    failure = throwable
+                }
+            },
+            "sync-test-worker",
+        )
+        thread.start()
+        thread.join()
+        failure?.let { throwable -> throw throwable }
+    }
+
+    private fun runSyncBatchOnWorker() {
+        val cursorPair = SyncCursorPair(
+            -1L,
+            TEST_TIMESTAMP_MILLIS + 1_000L,
+        )
+        val smsToAdd = ArrayList<DatabaseMessages.SmsMessage>()
+        val mmsToAdd = LongSparseArray<DatabaseMessages.MmsMessage>()
+        val messagesToDelete = ArrayList<DatabaseMessages.LocalDatabaseMessage>()
+
+        cursorPair.query(database)
+
+        try {
+            cursorPair.scan(
+                4_000,
+                80,
+                smsToAdd,
+                mmsToAdd,
+                messagesToDelete,
+                dataModel.syncManager.threadInfoCache,
+            )
+        } finally {
+            cursorPair.close()
+        }
+
+        val mmsMessagesToAdd = mmsToAdd.values()
+        mmsMessagesToAdd.forEach { mms ->
+            if (mms.mType == Mms.MESSAGE_BOX_INBOX) {
+                mms.setSender(telephonyProvider.senderForThread(threadId = mms.mThreadId))
+            }
+        }
+
+        val batch = SyncMessageBatch(
+            smsToAdd,
+            ArrayList(mmsMessagesToAdd),
+            messagesToDelete,
+            dataModel.syncManager.threadInfoCache,
+        )
+        batch.updateLocalDatabase()
+    }
+
+    private fun isSynchronized(): Boolean {
+        return SyncCursorPair(
+            -1L,
+            TEST_TIMESTAMP_MILLIS + 1_000L,
+        ).isSynchronized(database)
+    }
+
+    private fun isMmsNotificationDownloadCountSynchronized(
+        localCount: Int,
+        remoteCount: Int,
+    ): Boolean {
+        return IsMmsNotificationDownloadCountSynchronized(
+            context = context,
+            database = database,
+        ).invoke(
+            localCount = localCount,
+            remoteCount = remoteCount,
+            localSelection = ALL_MESSAGES_SELECTION,
+            localSelectionArgs = null,
+            smsSelection = ALL_MESSAGES_SELECTION,
+            smsSelectionArgs = null,
+            mmsSelection = ALL_MESSAGES_SELECTION,
+            mmsSelectionArgs = null,
+        )
+    }
+
+    private fun seedIncomingMmsPushNotification(
+        id: Long,
+        status: Int,
+        timestampMillis: Long,
+        mmsExpiryMillis: Long = UNEXPIRED_MMS_EXPIRY_MILLIS,
+        selfParticipantId: Long = SELF_PARTICIPANT_DB_ID,
+    ) {
+        seedLocalMessage(
+            id = id,
+            protocol = MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION,
+            status = status,
+            messageUri = "content://mms/$id",
+            timestampMillis = timestampMillis,
+            mmsExpiryMillis = mmsExpiryMillis,
+            selfParticipantId = selfParticipantId,
+        )
+    }
+
+    private fun seedSelfParticipant(
+        id: Long = SELF_PARTICIPANT_DB_ID,
+        subId: Int = ParticipantData.DEFAULT_SELF_SUB_ID,
+    ) {
+        val values = ParticipantData
+            .getSelfParticipant(subId)
+            .toContentValues()
+        values.put(BaseColumns._ID, id)
+
+        database.insert(DatabaseHelper.PARTICIPANTS_TABLE, null, values)
+    }
+
+    private fun seedLocalMessage(
+        id: Long,
+        protocol: Int,
+        status: Int,
+        messageUri: String,
+        timestampMillis: Long,
+        mmsExpiryMillis: Long = UNEXPIRED_MMS_EXPIRY_MILLIS,
+        selfParticipantId: Long = SELF_PARTICIPANT_DB_ID,
+    ) {
+        val participantId = id + PARTICIPANT_ID_OFFSET
+        val conversationId = id + CONVERSATION_ID_OFFSET
+
+        database.insert(
+            DatabaseHelper.PARTICIPANTS_TABLE,
+            null,
+            contentValuesOf(
+                ParticipantColumns.SUB_ID to ParticipantData.OTHER_THAN_SELF_SUB_ID,
+                ParticipantColumns.SIM_SLOT_ID to -1,
+                ParticipantColumns.NORMALIZED_DESTINATION to "+1555$id",
+                ParticipantColumns.SEND_DESTINATION to "+1555$id",
+                ParticipantColumns.DISPLAY_DESTINATION to "+1555$id",
+                ParticipantColumns.FULL_NAME to "Issue 144 sender $id",
+                ParticipantColumns.FIRST_NAME to "Issue144-$id",
+                ParticipantColumns.CONTACT_ID to
+                    ParticipantData.PARTICIPANT_CONTACT_ID_NOT_RESOLVED,
+                ParticipantColumns.BLOCKED to 0,
+                ParticipantColumns.SUBSCRIPTION_COLOR to 0,
+                BaseColumns._ID to participantId,
+            ),
+        )
+        database.insert(
+            DatabaseHelper.CONVERSATIONS_TABLE,
+            null,
+            contentValuesOf(
+                ConversationColumns.SMS_THREAD_ID to id,
+                ConversationColumns.NAME to "Issue 144 conversation $id",
+                ConversationColumns.LATEST_MESSAGE_ID to id,
+                ConversationColumns.SNIPPET_TEXT to "Synthetic issue 144 message $id",
+                ConversationColumns.SORT_TIMESTAMP to timestampMillis,
+                ConversationColumns.LAST_READ_TIMESTAMP to 0L,
+                ConversationColumns.OTHER_PARTICIPANT_NORMALIZED_DESTINATION to "+1555$id",
+                ConversationColumns.CURRENT_SELF_ID to selfParticipantId.toString(),
+                ConversationColumns.PARTICIPANT_COUNT to 1,
+                ConversationColumns.NOTIFICATION_ENABLED to 1,
+                ConversationColumns.NOTIFICATION_VIBRATION to 1,
+                BaseColumns._ID to conversationId,
+            ),
+        )
+        database.insert(
+            DatabaseHelper.CONVERSATION_PARTICIPANTS_TABLE,
+            null,
+            contentValuesOf(
+                ConversationParticipantsColumns.CONVERSATION_ID to conversationId,
+                ConversationParticipantsColumns.PARTICIPANT_ID to participantId,
+            ),
+        )
+        database.insert(
+            DatabaseHelper.MESSAGES_TABLE,
+            null,
+            contentValuesOf(
+                MessageColumns.CONVERSATION_ID to conversationId,
+                MessageColumns.SENDER_PARTICIPANT_ID to participantId,
+                MessageColumns.SENT_TIMESTAMP to timestampMillis,
+                MessageColumns.RECEIVED_TIMESTAMP to timestampMillis,
+                MessageColumns.PROTOCOL to protocol,
+                MessageColumns.STATUS to status,
+                MessageColumns.SEEN to 0,
+                MessageColumns.READ to 0,
+                MessageColumns.SMS_MESSAGE_URI to messageUri,
+                MessageColumns.MMS_TRANSACTION_ID to transactionIdFor(id = id),
+                MessageColumns.MMS_CONTENT_LOCATION to "http://example.invalid/mms/$id",
+                MessageColumns.MMS_EXPIRY to mmsExpiryMillis,
+                MessageColumns.RAW_TELEPHONY_STATUS to 0,
+                MessageColumns.SELF_PARTICIPANT_ID to selfParticipantId,
+                BaseColumns._ID to id,
+            ),
+        )
+    }
+
+    private fun countMessages(id: Long): Int {
+        return countRows(
+            table = DatabaseHelper.MESSAGES_TABLE,
+            selection = "${BaseColumns._ID}=?",
+            selectionArgs = arrayOf(id.toString()),
+        )
+    }
+
+    private fun countMessagesByUri(messageUri: String): Int {
+        return countRows(
+            table = DatabaseHelper.MESSAGES_TABLE,
+            selection = "${MessageColumns.SMS_MESSAGE_URI}=?",
+            selectionArgs = arrayOf(messageUri),
+        )
+    }
+
+    private fun countConversations(id: String): Int {
+        return countRows(
+            table = DatabaseHelper.CONVERSATIONS_TABLE,
+            selection = "${BaseColumns._ID}=?",
+            selectionArgs = arrayOf(id),
+        )
+    }
+
+    private fun countRows(
+        table: String,
+        selection: String,
+        selectionArgs: Array<String>,
+    ): Int {
+        return database.query(
+            table,
+            arrayOf(BaseColumns._ID),
+            selection,
+            selectionArgs,
+            null,
+            null,
+            null,
+            null,
+        ).use { cursor ->
+            cursor.count
+        }
+    }
+
+    private fun readMessage(id: Long): MessageData? {
+        return database.query(
+            DatabaseHelper.MESSAGES_TABLE,
+            MessageData.getProjection(),
+            "${BaseColumns._ID}=?",
+            arrayOf(id.toString()),
+            null,
+            null,
+            null,
+            null,
+        ).use { cursor ->
+            when {
+                !cursor.moveToFirst() -> null
+                else -> {
+                    MessageData().apply {
+                        bind(cursor)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun assertMessageCount(
+        id: Long,
+        expectedCount: Int,
+        failureMessage: String = "Unexpected message count for $id",
+    ) {
+        assertEquals(failureMessage, expectedCount, countMessages(id))
+    }
+
+    private fun assertIncomingMmsNotificationStillDownloading(id: Long) {
+        val message = requireNotNull(readMessage(id = id))
+
+        assertEquals(MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION, message.getProtocol())
+        assertEquals(MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING, message.getStatus())
+        assertMessageCount(id = id, expectedCount = 1)
+    }
+
+    private fun deleteSyntheticRows() {
+        database.delete(
+            DatabaseHelper.CONVERSATION_PARTICIPANTS_TABLE,
+            "${ConversationParticipantsColumns.CONVERSATION_ID} BETWEEN ? AND ?",
+            arrayOf(
+                (TEST_ID_BASE + CONVERSATION_ID_OFFSET).toString(),
+                (TEST_ID_BASE + protectedStatusCount + CONVERSATION_ID_OFFSET).toString(),
+            ),
+        )
+        database.delete(
+            DatabaseHelper.MESSAGES_TABLE,
+            "${BaseColumns._ID} BETWEEN ? AND ?",
+            arrayOf(
+                TEST_ID_BASE.toString(),
+                (TEST_ID_BASE + protectedStatusCount).toString(),
+            ),
+        )
+        database.delete(
+            DatabaseHelper.CONVERSATIONS_TABLE,
+            "${BaseColumns._ID} BETWEEN ? AND ?",
+            arrayOf(
+                (TEST_ID_BASE + CONVERSATION_ID_OFFSET).toString(),
+                (TEST_ID_BASE + protectedStatusCount + CONVERSATION_ID_OFFSET).toString(),
+            ),
+        )
+        database.delete(
+            DatabaseHelper.PARTICIPANTS_TABLE,
+            "${BaseColumns._ID} BETWEEN ? AND ?",
+            arrayOf(
+                (TEST_ID_BASE + PARTICIPANT_ID_OFFSET).toString(),
+                (TEST_ID_BASE + protectedStatusCount + PARTICIPANT_ID_OFFSET).toString(),
+            ),
+        )
+    }
+
+    private class FakeTelephonyProvider : ContentProvider() {
+        private val mmsRows = mutableListOf<Map<String, Any?>>()
+        private val threadRecipientIds = mutableMapOf<Long, Long>()
+
+        var remoteMmsIdBatchQueryCount = 0
+            private set
+
+        var remoteMmsReplacementQueryCount = 0
+            private set
+
+        var failRemoteMmsIdBatchQuery = false
+        var failRemoteMmsReplacementQuery = false
+
+        private val matcher = UriMatcher(UriMatcher.NO_MATCH).apply {
+            addURI("sms", null, SMS)
+            addURI("mms", null, MMS)
+            addURI("mms-sms", "conversations", THREADS)
+            addURI("mms-sms", "canonical-address/#", CANONICAL_ADDRESS)
+        }
+
+        override fun onCreate(): Boolean {
+            return true
+        }
+
+        override fun query(
+            uri: Uri,
+            projection: Array<out String>?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+            sortOrder: String?,
+        ): Cursor {
+            return when (matcher.match(uri)) {
+                SMS -> {
+                    val projectedColumns = projection ?: smsProjectionColumns
+
+                    if (projectedColumns.isCountProjection()) {
+                        countCursor(projection = projectedColumns, count = 0)
+                    } else {
+                        matrixCursor(projectedColumns, emptyList())
+                    }
+                }
+                MMS -> {
+                    val projectedColumns = projection ?: mmsProjectionColumns
+                    val rows = selectedMmsRows(
+                        selection = selection,
+                        selectionArgs = selectionArgs,
+                    )
+
+                    if (projectedColumns.isCountProjection()) {
+                        countCursor(projection = projectedColumns, count = rows.size)
+                    } else {
+                        matrixCursor(projectedColumns, rows)
+                    }
+                }
+                THREADS -> matrixCursor(
+                    projection ?: threadProjectionColumns,
+                    threadRows(selectionArgs = selectionArgs),
+                )
+                CANONICAL_ADDRESS -> matrixCursor(
+                    projection ?: canonicalAddressProjectionColumns,
+                    canonicalAddressRows(uri = uri),
+                )
+                else -> matrixCursor(projection ?: emptyArray(), emptyList())
+            }
+        }
+
+        override fun getType(uri: Uri): String? {
+            return null
+        }
+
+        override fun insert(uri: Uri, values: ContentValues?): Uri? {
+            return null
+        }
+
+        override fun delete(
+            uri: Uri,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int {
+            return 0
+        }
+
+        override fun update(
+            uri: Uri,
+            values: ContentValues?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int {
+            return 0
+        }
+
+        fun addMmsRow(
+            id: Long,
+            timestampMillis: Long,
+            threadId: Long = id,
+            transactionId: String? = transactionIdFor(id = id),
+            messageType: Int = PduHeaders.MESSAGE_TYPE_RETRIEVE_CONF,
+        ) {
+            mmsRows += mapOf(
+                Mms._ID to id,
+                Mms.MESSAGE_BOX to Mms.MESSAGE_BOX_INBOX,
+                Mms.SUBJECT to null,
+                Mms.SUBJECT_CHARSET to 106,
+                Mms.MESSAGE_SIZE to 0,
+                Mms.DATE to timestampMillis / 1_000L,
+                Mms.DATE_SENT to 0L,
+                Mms.THREAD_ID to threadId,
+                Mms.PRIORITY to 129,
+                Mms.STATUS to 0,
+                Mms.READ to 0,
+                Mms.SEEN to 0,
+                Mms.CONTENT_LOCATION to "http://example.invalid/mms/$id",
+                Mms.TRANSACTION_ID to transactionId,
+                Mms.MESSAGE_TYPE to messageType,
+                Mms.EXPIRY to (timestampMillis + 86_400_000L) / 1_000L,
+                Mms.RESPONSE_STATUS to 0,
+                Mms.RETRIEVE_STATUS to 0,
+                Mms.SUBSCRIPTION_ID to ParticipantData.DEFAULT_SELF_SUB_ID,
+            )
+        }
+
+        fun setThreadRecipient(threadId: Long, recipientId: Long) {
+            threadRecipientIds[threadId] = recipientId
+        }
+
+        fun senderForThread(threadId: Long): String {
+            val recipientId = threadRecipientIds[threadId] ?: threadId
+            return "+1555$recipientId"
+        }
+
+        private fun countCursor(projection: Array<out String>, count: Int): MatrixCursor {
+            return MatrixCursor(projection).apply {
+                addRow(arrayOf(count))
+            }
+        }
+
+        private fun matrixCursor(
+            projection: Array<out String>,
+            rows: List<Map<String, Any?>>,
+        ): MatrixCursor {
+            return MatrixCursor(projection).apply {
+                rows.forEach { row ->
+                    projection
+                        .map { column -> row[column] }
+                        .toTypedArray()
+                        .let(::addRow)
+                }
+            }
+        }
+
+        private fun selectedMmsRows(
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): List<Map<String, Any?>> {
+            return when {
+                selection == null -> orderedMmsRows()
+                selection == "${Mms._ID}=?" -> selectedMmsRowsById(selectionArgs = selectionArgs)
+                selection.isMmsIdBatchSelection() -> {
+                    remoteMmsIdBatchQueryCount++
+                    if (failRemoteMmsIdBatchQuery) {
+                        throw IllegalArgumentException("Remote MMS id batch query failed")
+                    }
+
+                    selectedMmsRowsByIds(selectionArgs = selectionArgs)
+                }
+                selection.isReplacementSelection() -> {
+                    remoteMmsReplacementQueryCount++
+                    if (failRemoteMmsReplacementQuery) {
+                        throw IllegalStateException("Remote MMS replacement query failed")
+                    }
+
+                    selectedReplacementMmsRows(
+                        selection = selection,
+                        selectionArgs = selectionArgs,
+                    )
+                }
+                selection.isSyncMmsSelection() -> orderedMmsRows()
+                else -> error("Unexpected MMS query: selection=$selection")
+            }
+        }
+
+        private fun selectedMmsRowsById(
+            selectionArgs: Array<out String>?,
+        ): List<Map<String, Any?>> {
+            val rowId = selectionArgs?.firstOrNull()?.toLongOrNull()
+                ?: error("Missing MMS row id selection arg")
+            return selectedMmsRowsByIds(rowIds = setOf(rowId))
+        }
+
+        private fun selectedMmsRowsByIds(
+            selectionArgs: Array<out String>?,
+        ): List<Map<String, Any?>> {
+            val rowIds = selectionArgs
+                ?.map { value -> value.toLong() }
+                ?.toSet()
+                ?: error("Missing MMS row id selection args")
+            return selectedMmsRowsByIds(rowIds = rowIds)
+        }
+
+        private fun selectedMmsRowsByIds(rowIds: Set<Long>): List<Map<String, Any?>> {
+            return orderedMmsRows().filter { row -> (row[Mms._ID] as Long) in rowIds }
+        }
+
+        private fun selectedReplacementMmsRows(
+            selection: String,
+            selectionArgs: Array<out String>?,
+        ): List<Map<String, Any?>> {
+            val args = selectionArgs ?: error("Missing replacement MMS selection args")
+            val transactionIdCount = selection.inClausePlaceholderCount(column = Mms.TRANSACTION_ID)
+            val messageBoxArgIndex = args.size - transactionIdCount - 2
+            check(messageBoxArgIndex >= 0) {
+                "Replacement MMS selection args do not match selection: $selection"
+            }
+
+            val messageBox = args[messageBoxArgIndex].toInt()
+            val messageType = args[messageBoxArgIndex + 1].toInt()
+            val transactionIds = args
+                .drop(messageBoxArgIndex + 2)
+                .toSet()
+
+            return orderedMmsRows()
+                .filter { row -> row[Mms.MESSAGE_BOX] == messageBox }
+                .filter { row -> row[Mms.MESSAGE_TYPE] == messageType }
+                .filter { row -> (row[Mms.TRANSACTION_ID] as? String) in transactionIds }
+        }
+
+        private fun orderedMmsRows(): List<Map<String, Any?>> {
+            return mmsRows.sortedByDescending { row -> row[Mms.DATE] as Long }
+        }
+
+        private fun threadRows(selectionArgs: Array<out String>?): List<Map<String, Any?>> {
+            val threadId = selectionArgs?.firstOrNull()?.toLongOrNull() ?: return emptyList()
+            val recipientId = threadRecipientIds[threadId] ?: threadId
+
+            return listOf(
+                mapOf(
+                    BaseColumns._ID to threadId,
+                    THREAD_RECIPIENT_IDS to recipientId,
+                ),
+            )
+        }
+
+        private fun canonicalAddressRows(uri: Uri): List<Map<String, Any?>> {
+            val recipientId = uri.lastPathSegment ?: return emptyList()
+
+            return listOf(
+                mapOf(CANONICAL_ADDRESS_COLUMN to "+1555$recipientId"),
+            )
+        }
+
+        private companion object {
+            private const val SMS = 1
+            private const val MMS = 2
+            private const val THREADS = 3
+            private const val CANONICAL_ADDRESS = 4
+        }
+    }
+
+    private companion object {
+        private const val SELF_PARTICIPANT_DB_ID = 1L
+        private const val OTHER_SELF_PARTICIPANT_DB_ID = 2L
+        private const val OTHER_SELF_PARTICIPANT_SUB_ID = 2
+        private const val TEST_ID_BASE = 144_000L
+        private const val PARTICIPANT_ID_OFFSET = 10_000L
+        private const val CONVERSATION_ID_OFFSET = 20_000L
+        private const val TEST_TIMESTAMP_MILLIS = 1_780_920_000_000L
+        private const val EXPIRED_MMS_EXPIRY_MILLIS = 1L
+        private const val UNKNOWN_MMS_EXPIRY_MILLIS = 0L
+        private const val UNEXPIRED_MMS_EXPIRY_MILLIS = 4_102_444_800_000L
+        private const val ALL_MESSAGES_SELECTION = "1=1"
+        private const val THREAD_RECIPIENT_IDS = "recipient_ids"
+        private const val CANONICAL_ADDRESS_COLUMN = "address"
+
+        private val protectedStatusCount = mmsNotificationDownloadStatuses.size.toLong()
+
+        private val terminalMmsNotificationStatuses = intArrayOf(
+            MessageData.BUGLE_STATUS_INCOMING_DOWNLOAD_FAILED,
+            MessageData.BUGLE_STATUS_INCOMING_EXPIRED_OR_NOT_AVAILABLE,
+        )
+
+        private val smsProjectionColumns = arrayOf(
+            Sms._ID,
+            Sms.TYPE,
+            Sms.ADDRESS,
+            Sms.BODY,
+            Sms.DATE,
+            Sms.DATE_SENT,
+            Sms.THREAD_ID,
+            Sms.STATUS,
+            Sms.READ,
+            Sms.SEEN,
+            Sms.SUBSCRIPTION_ID,
+        )
+
+        private val mmsProjectionColumns = arrayOf(
+            Mms._ID,
+            Mms.MESSAGE_BOX,
+            Mms.SUBJECT,
+            Mms.SUBJECT_CHARSET,
+            Mms.MESSAGE_SIZE,
+            Mms.DATE,
+            Mms.DATE_SENT,
+            Mms.THREAD_ID,
+            Mms.PRIORITY,
+            Mms.STATUS,
+            Mms.READ,
+            Mms.SEEN,
+            Mms.CONTENT_LOCATION,
+            Mms.TRANSACTION_ID,
+            Mms.MESSAGE_TYPE,
+            Mms.EXPIRY,
+            Mms.RESPONSE_STATUS,
+            Mms.RETRIEVE_STATUS,
+            Mms.SUBSCRIPTION_ID,
+        )
+
+        private val threadProjectionColumns = arrayOf(
+            BaseColumns._ID,
+            THREAD_RECIPIENT_IDS,
+        )
+
+        private val canonicalAddressProjectionColumns = arrayOf(
+            CANONICAL_ADDRESS_COLUMN,
+        )
+
+        private fun transactionIdFor(id: Long): String {
+            return "issue144-tx-$id"
+        }
+    }
+}
+
+private fun Array<out String>.isCountProjection(): Boolean {
+    return size == 1 && first() == "count()"
+}
+
+private fun String.isMmsIdBatchSelection(): Boolean {
+    return startsWith("${Mms._ID} IN (")
+}
+
+private fun String.isReplacementSelection(): Boolean {
+    return contains("${Mms.MESSAGE_BOX}=?") &&
+        contains("${Mms.MESSAGE_TYPE}=?") &&
+        contains("${Mms.TRANSACTION_ID} IN (")
+}
+
+private fun String.isSyncMmsSelection(): Boolean {
+    return contains("${Mms.MESSAGE_BOX} IN (") &&
+        contains("${Mms.MESSAGE_TYPE} IN (")
+}
+
+private fun String.inClausePlaceholderCount(column: String): Int {
+    val inClause = substringAfter("$column IN (", missingDelimiterValue = "")
+        .substringBefore(")")
+    check(inClause.isNotEmpty()) {
+        "Missing IN clause for $column in $this"
+    }
+
+    return inClause.count { char -> char == '?' }
+}
+
+private fun <T> LongSparseArray<T>.values(): List<T> {
+    return (0 until size()).map { index -> valueAt(index) }
+}
+
+internal class SyncMessagesActionMmsReplacementRaceTestApplication : BugleApplication() {
+    override fun onCreate() {
+        setTestsRunning()
+    }
+}

--- a/app/src/test/kotlin/com/android/messaging/datamodel/action/mms/MmsNotificationDownloadTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/datamodel/action/mms/MmsNotificationDownloadTest.kt
@@ -1,0 +1,143 @@
+package com.android.messaging.datamodel.action.mms
+
+import com.android.messaging.datamodel.data.MessageData
+import com.android.messaging.sms.DatabaseMessages.LocalDatabaseMessage
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MmsNotificationDownloadTest {
+
+    @Test
+    fun mmsNotificationDownloadStatuses_containsOnlyActiveDownloadStatuses() {
+        assertArrayEquals(
+            intArrayOf(
+                MessageData.BUGLE_STATUS_INCOMING_RETRYING_MANUAL_DOWNLOAD,
+                MessageData.BUGLE_STATUS_INCOMING_MANUAL_DOWNLOADING,
+                MessageData.BUGLE_STATUS_INCOMING_RETRYING_AUTO_DOWNLOAD,
+                MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+            ),
+            mmsNotificationDownloadStatuses,
+        )
+    }
+
+    @Test
+    fun isMmsNotificationExpired_returnsTrueForPastPositiveExpiry() {
+        val result = isMmsNotificationExpired(
+            mmsExpiry = 999L,
+            nowMillis = 1_000L,
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun isMmsNotificationExpired_returnsFalseForFutureExpiry() {
+        val result = isMmsNotificationExpired(
+            mmsExpiry = 1_001L,
+            nowMillis = 1_000L,
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun isMmsNotificationExpired_returnsFalseForUnknownExpiry() {
+        val result = isMmsNotificationExpired(
+            mmsExpiry = 0L,
+            nowMillis = 1_000L,
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun shouldProtectMmsNotificationDownload_returnsTrueForUnexpiredDownloadNotification() {
+        val result = shouldProtectMmsNotificationDownload(
+            localMessage = localMessage(
+                protocol = MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION,
+                status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+                mmsExpiry = Long.MAX_VALUE,
+            ),
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun shouldProtectMmsNotificationDownload_returnsFalseForExpiredDownloadNotification() {
+        val result = shouldProtectMmsNotificationDownload(
+            localMessage = localMessage(
+                protocol = MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION,
+                status = MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+                mmsExpiry = 1L,
+            ),
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun shouldProtectMmsNotificationDownload_returnsFalseForCompletedMms() {
+        val result = shouldProtectMmsNotificationDownload(
+            localMessage = localMessage(
+                protocol = MessageData.PROTOCOL_MMS,
+                status = MessageData.BUGLE_STATUS_INCOMING_COMPLETE,
+                mmsExpiry = Long.MAX_VALUE,
+            ),
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun shouldProtectMmsNotificationDownload_returnsFalseForYetToManualDownloadNotification() {
+        val result = shouldProtectMmsNotificationDownload(
+            localMessage = localMessage(
+                protocol = MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION,
+                status = MessageData.BUGLE_STATUS_INCOMING_YET_TO_MANUAL_DOWNLOAD,
+                mmsExpiry = Long.MAX_VALUE,
+            ),
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun shouldProtectMmsNotificationDownload_returnsFalseForTerminalNotificationStatuses() {
+        listOf(
+            MessageData.BUGLE_STATUS_INCOMING_DOWNLOAD_FAILED,
+            MessageData.BUGLE_STATUS_INCOMING_EXPIRED_OR_NOT_AVAILABLE,
+        ).forEach { status ->
+            val result = shouldProtectMmsNotificationDownload(
+                localMessage = localMessage(
+                    protocol = MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION,
+                    status = status,
+                    mmsExpiry = Long.MAX_VALUE,
+                ),
+            )
+
+            assertFalse("Status $status should not be protected", result)
+        }
+    }
+
+    private fun localMessage(
+        protocol: Int,
+        status: Int,
+        mmsExpiry: Long,
+    ): LocalDatabaseMessage {
+        return LocalDatabaseMessage(
+            1L,
+            protocol,
+            "content://mms/1",
+            1L,
+            "conversation",
+            status,
+            mmsExpiry,
+        )
+    }
+}

--- a/src/com/android/messaging/datamodel/action/SyncCursorPair.java
+++ b/src/com/android/messaging/datamodel/action/SyncCursorPair.java
@@ -21,6 +21,9 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
 import android.provider.Telephony.Mms;
 import android.provider.Telephony.Sms;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.collection.LongSparseArray;
 import android.text.TextUtils;
 
@@ -30,6 +33,8 @@ import com.android.messaging.datamodel.DatabaseWrapper;
 import com.android.messaging.datamodel.SyncManager;
 import com.android.messaging.datamodel.DatabaseHelper.MessageColumns;
 import com.android.messaging.datamodel.SyncManager.ThreadInfoCache;
+import com.android.messaging.datamodel.action.mms.IsMmsNotificationDownloadCountSynchronized;
+import com.android.messaging.datamodel.action.mms.MmsNotificationDownloadState;
 import com.android.messaging.datamodel.data.MessageData;
 import com.android.messaging.mmslib.SqliteWrapper;
 import com.android.messaging.sms.DatabaseMessages;
@@ -57,7 +62,7 @@ class SyncCursorPair {
     static final long SYNC_COMPLETE = -1L;
     static final long SYNC_STARTING = Long.MAX_VALUE;
 
-    private CursorIterator mLocalCursorIterator;
+    private LocalCursorIterator mLocalCursorIterator;
     private CursorIterator mRemoteCursorsIterator;
 
     private final String mLocalSelection;
@@ -152,7 +157,7 @@ class SyncCursorPair {
             final ArrayList<LocalDatabaseMessage> messagesToDelete,
             final SyncManager.ThreadInfoCache threadInfoCache) {
         // Set of local messages matched with the timestamp of a remote message
-        final Set<DatabaseMessage> matchedLocalMessages = Sets.newHashSet();
+        final Set<LocalDatabaseMessage> matchedLocalMessages = Sets.newHashSet();
         // Set of remote messages matched with the timestamp of a local message
         final Set<DatabaseMessage> matchedRemoteMessages = Sets.newHashSet();
         long lastTimestampMillis = SYNC_STARTING;
@@ -161,7 +166,7 @@ class SyncCursorPair {
         int remoteCount = 0;
         // Seed the initial values of remote and local messages for comparison
         DatabaseMessage remoteMessage = mRemoteCursorsIterator.next();
-        DatabaseMessage localMessage = mLocalCursorIterator.next();
+        LocalDatabaseMessage localMessage = mLocalCursorIterator.next();
         // Iterate through messages on both sides in reverse time order
         // Import messages in remote not in local, delete messages in local not in remote
         while (localCount + remoteCount < maxMessagesToScan && smsToAdd.size()
@@ -175,8 +180,7 @@ class SyncCursorPair {
                         localMessage.getTimestampInMillis()
                             > remoteMessage.getTimestampInMillis())) {
                 // Found a local message that is not in remote db
-                // Delete the local message
-                messagesToDelete.add((LocalDatabaseMessage) localMessage);
+                maybeDeleteLocalMessage(messagesToDelete, localMessage);
                 lastTimestampMillis = Math.min(lastTimestampMillis,
                         localMessage.getTimestampInMillis());
                 // Advance to next local message
@@ -200,7 +204,7 @@ class SyncCursorPair {
                 lastTimestampMillis = Math.min(lastTimestampMillis, matchedTimestamp);
                 // Get the next local and remote messages
                 final DatabaseMessage remoteMessagePeek = mRemoteCursorsIterator.next();
-                final DatabaseMessage localMessagePeek = mLocalCursorIterator.next();
+                final LocalDatabaseMessage localMessagePeek = mLocalCursorIterator.next();
                 // Check if only one message on each side matches the current timestamp
                 // by looking at the next messages on both sides. If they are either null
                 // (meaning no more messages) or having a different timestamp. We want
@@ -216,8 +220,7 @@ class SyncCursorPair {
                     // that matches the same timestamp
                     if (!remoteMessage.equals(localMessage)) {
                         // local != remote
-                        // Delete local message
-                        messagesToDelete.add((LocalDatabaseMessage) localMessage);
+                        maybeDeleteLocalMessage(messagesToDelete, localMessage);
                         // Add remote message
                         saveMessageToAdd(smsToAdd, mmsToAdd, remoteMessage, threadInfoCache);
                     }
@@ -250,7 +253,7 @@ class SyncCursorPair {
                             localMessage.getTimestampInMillis() == matchedTimestamp) {
                         if (matchedLocalMessages.contains(localMessage)) {
                             // Duplicate message is local database is deleted
-                            messagesToDelete.add((LocalDatabaseMessage) localMessage);
+                            messagesToDelete.add(localMessage);
                         } else {
                             matchedLocalMessages.add(localMessage);
                         }
@@ -258,9 +261,9 @@ class SyncCursorPair {
                         localMessage = mLocalCursorIterator.next();
                     }
                     // Delete messages local only
-                    for (final DatabaseMessage msg : Sets.difference(
+                    for (final LocalDatabaseMessage msg : Sets.difference(
                             matchedLocalMessages, matchedRemoteMessages)) {
-                        messagesToDelete.add((LocalDatabaseMessage) msg);
+                        maybeDeleteLocalMessage(messagesToDelete, msg);
                     }
                     // Add messages remote only
                     for (final DatabaseMessage msg : Sets.difference(
@@ -271,14 +274,6 @@ class SyncCursorPair {
             }
         }
         return lastTimestampMillis;
-    }
-
-    DatabaseMessage getLocalMessage() {
-        return mLocalCursorIterator.next();
-    }
-
-    DatabaseMessage getRemoteMessage() {
-        return mRemoteCursorsIterator.next();
     }
 
     int getLocalPosition() {
@@ -340,12 +335,16 @@ class SyncCursorPair {
                 MessageColumns.SMS_MESSAGE_URI,
                 MessageColumns.PROTOCOL,
                 MessageColumns.CONVERSATION_ID,
+                MessageColumns.STATUS,
+                MessageColumns.MMS_EXPIRY,
         };
         private static final int INDEX_MESSAGE_ID = 0;
         private static final int INDEX_MESSAGE_TIMESTAMP = 1;
         private static final int INDEX_SMS_MESSAGE_URI = 2;
         private static final int INDEX_MESSAGE_SMS_TYPE = 3;
         private static final int INDEX_CONVERSATION_ID = 4;
+        private static final int INDEX_MESSAGE_STATUS = 5;
+        private static final int INDEX_MESSAGE_MMS_EXPIRY = 6;
     }
 
     /**
@@ -360,7 +359,18 @@ class SyncCursorPair {
                 cursor.getInt(LocalMessageQuery.INDEX_MESSAGE_SMS_TYPE),
                 cursor.getString(LocalMessageQuery.INDEX_SMS_MESSAGE_URI),
                 cursor.getLong(LocalMessageQuery.INDEX_MESSAGE_TIMESTAMP),
-                cursor.getString(LocalMessageQuery.INDEX_CONVERSATION_ID));
+                cursor.getString(LocalMessageQuery.INDEX_CONVERSATION_ID),
+                cursor.getInt(LocalMessageQuery.INDEX_MESSAGE_STATUS),
+                cursor.getLong(LocalMessageQuery.INDEX_MESSAGE_MMS_EXPIRY));
+    }
+
+    private static void maybeDeleteLocalMessage(
+            @NonNull final ArrayList<LocalDatabaseMessage> messagesToDelete,
+            @NonNull final LocalDatabaseMessage localMessage
+    ) {
+        if (!MmsNotificationDownloadState.shouldProtectMmsNotificationDownload(localMessage)) {
+            messagesToDelete.add(localMessage);
+        }
     }
 
     /**
@@ -395,7 +405,8 @@ class SyncCursorPair {
         }
 
         @Override
-        public DatabaseMessage next() {
+        @Nullable
+        public LocalDatabaseMessage next() {
             if (mCursor != null && mCursor.moveToNext()) {
                 return getLocalDatabaseMessage(mCursor);
             }
@@ -681,17 +692,11 @@ class SyncCursorPair {
                     null/*orderBy*/);
             final int mmsCount = getCountFromCursor(remoteMmsCursor);
             final int remoteCount = smsCount + mmsCount;
-            final boolean isInSync = (localCount == remoteCount);
-            if (isInSync) {
-                if (LogUtil.isLoggable(TAG, LogUtil.DEBUG)) {
-                    LogUtil.d(TAG, "SyncCursorPair: Same # of local and remote messages = "
-                            + localCount);
-                }
-            } else {
-                LogUtil.i(TAG, "SyncCursorPair: Not in sync; # local messages = " + localCount
-                        + ", # remote message = " + remoteCount);
-            }
-            return isInSync;
+            final IsMmsNotificationDownloadCountSynchronized isMmsDownloadCountSynchronized =
+                    new IsMmsNotificationDownloadCountSynchronized(context, db);
+            return isMmsDownloadCountSynchronized.invoke(
+                    localCount, remoteCount, localSelection, localSelectionArgs,
+                    smsSelection, smsSelectionArgs, mmsSelection, mmsSelectionArgs);
         } catch (final Exception e) {
             LogUtil.e(TAG, "SyncCursorPair: failed to query local or remote message counts", e);
             // If something is wrong in querying database, assume we are synced so

--- a/src/com/android/messaging/datamodel/action/SyncMessageBatch.java
+++ b/src/com/android/messaging/datamodel/action/SyncMessageBatch.java
@@ -30,6 +30,7 @@ import com.android.messaging.datamodel.DatabaseHelper.ConversationColumns;
 import com.android.messaging.datamodel.DatabaseHelper.MessageColumns;
 import com.android.messaging.datamodel.DatabaseWrapper;
 import com.android.messaging.datamodel.SyncManager.ThreadInfoCache;
+import com.android.messaging.datamodel.action.mms.FindMmsNotificationToReplace;
 import com.android.messaging.datamodel.data.MessageData;
 import com.android.messaging.datamodel.data.ParticipantData;
 import com.android.messaging.mmslib.pdu.PduHeaders;
@@ -228,7 +229,7 @@ class SyncMessageBatch {
      * @param mms
      */
     private void storeMms(final DatabaseWrapper db, final MmsMessage mms) {
-        if (mms.mParts.size() < 1) {
+        if (mms.mParts.isEmpty()) {
             LogUtil.w(TAG, "SyncMessageBatch: MMS " + mms.mUri + " has no parts");
         }
 
@@ -236,6 +237,7 @@ class SyncMessageBatch {
         final boolean isOutgoing = mms.mType != Mms.MESSAGE_BOX_INBOX;
         final boolean isNotification = (mms.mMmsMessageType ==
                 PduHeaders.MESSAGE_TYPE_NOTIFICATION_IND);
+        final boolean canReplaceNotification = !isOutgoing && !isNotification;
 
         final String senderId = mms.mSender;
 
@@ -256,6 +258,12 @@ class SyncMessageBatch {
                 self : ParticipantData.getFromRawPhoneBySimLocale(senderId, mms.getSubId());
         final String participantId = (isOutgoing ? selfId :
                 BugleDatabaseOperations.getOrCreateParticipantInTransaction(db, sender));
+        MessageData notificationToReplace = null;
+        if (canReplaceNotification) {
+            final FindMmsNotificationToReplace findMmsNotificationToReplace =
+                    new FindMmsNotificationToReplace(db);
+            notificationToReplace = findMmsNotificationToReplace.invoke(mms, selfId, participantId);
+        }
 
         final int bugleStatus = MmsUtils.bugleStatusForMms(isOutgoing, isNotification, mms.mType);
 
@@ -270,7 +278,14 @@ class SyncMessageBatch {
 
         // Inserting mms content into messages table
         try {
-            BugleDatabaseOperations.insertNewMessageInTransaction(db, message);
+            if (notificationToReplace == null) {
+                BugleDatabaseOperations.insertNewMessageInTransaction(db, message);
+            } else {
+                message.updateMessageId(notificationToReplace.getMessageId());
+                BugleDatabaseOperations.updateMessageInTransaction(db, message);
+                removeMessageToDelete(notificationToReplace.getMessageId());
+                mConversationsToUpdate.add(notificationToReplace.getConversationId());
+            }
         } catch (SQLiteConstraintException e) {
             rethrowSQLiteConstraintExceptionWithDetails(e, db, mms.mUri, mms.mThreadId,
                     conversationId, selfId, participantId);
@@ -284,6 +299,14 @@ class SyncMessageBatch {
 
         // Keep track of updated conversation for later updating the conversation snippet, etc.
         mConversationsToUpdate.add(conversationId);
+    }
+
+    private void removeMessageToDelete(final String messageId) {
+        for (int i = mMessagesToDelete.size() - 1; i >= 0; i--) {
+            if (Long.toString(mMessagesToDelete.get(i).getLocalId()).equals(messageId)) {
+                mMessagesToDelete.remove(i);
+            }
+        }
     }
 
     // TODO: Remove this after we no longer see this crash (b/18375758)

--- a/src/com/android/messaging/datamodel/action/mms/FindMmsNotificationToReplace.kt
+++ b/src/com/android/messaging/datamodel/action/mms/FindMmsNotificationToReplace.kt
@@ -1,0 +1,78 @@
+package com.android.messaging.datamodel.action.mms
+
+import android.database.Cursor
+import com.android.messaging.datamodel.DatabaseHelper
+import com.android.messaging.datamodel.DatabaseHelper.MessageColumns
+import com.android.messaging.datamodel.DatabaseWrapper
+import com.android.messaging.datamodel.data.MessageData
+import com.android.messaging.sms.DatabaseMessages.MmsMessage
+import com.android.messaging.util.LogUtil
+
+internal class FindMmsNotificationToReplace(
+    private val database: DatabaseWrapper,
+) {
+
+    operator fun invoke(
+        downloadedMms: MmsMessage,
+        selfId: String,
+        senderParticipantId: String,
+    ): MessageData? {
+        val transactionId = downloadedMms
+            .mTransactionId
+            ?.takeIf { it.isNotEmpty() }
+            ?: return null
+
+        val selection = "${MessageColumns.PROTOCOL}=? AND " +
+            "${MessageColumns.MMS_TRANSACTION_ID}=? AND " +
+            "${MessageColumns.SELF_PARTICIPANT_ID}=? AND " +
+            "${MessageColumns.STATUS} IN $mmsNotificationDownloadStatusInOperand"
+
+        val selectionArgs = arrayOf(
+            MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION.toString(),
+            transactionId,
+            selfId,
+            *mmsNotificationDownloadStatusArgs,
+        )
+
+        return database.query(
+            DatabaseHelper.MESSAGES_TABLE,
+            MessageData.getProjection(),
+            selection,
+            selectionArgs,
+            null,
+            null,
+            "${MessageColumns.RECEIVED_TIMESTAMP} DESC",
+        ).use { cursor ->
+            when {
+                !cursor.moveToNext() -> null
+                else -> {
+                    readNotificationToReplace(
+                        cursor = cursor,
+                        downloadedMms = downloadedMms,
+                        senderParticipantId = senderParticipantId,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun readNotificationToReplace(
+        cursor: Cursor,
+        downloadedMms: MmsMessage,
+        senderParticipantId: String,
+    ): MessageData {
+        val message = MessageData().apply {
+            bind(cursor)
+        }
+
+        if (senderParticipantId != message.participantId) {
+            LogUtil.w(
+                LogUtil.BUGLE_TAG,
+                "SyncMessageBatch: replacing MMS notification for ${downloadedMms.mUri} " +
+                    "even though sender participant differs",
+            )
+        }
+
+        return message
+    }
+}

--- a/src/com/android/messaging/datamodel/action/mms/IsMmsNotificationDownloadCountSynchronized.kt
+++ b/src/com/android/messaging/datamodel/action/mms/IsMmsNotificationDownloadCountSynchronized.kt
@@ -1,0 +1,527 @@
+package com.android.messaging.datamodel.action.mms
+
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.BaseColumns
+import android.provider.Telephony.Mms
+import android.provider.Telephony.Sms
+import androidx.core.net.toUri
+import com.android.messaging.datamodel.DatabaseHelper
+import com.android.messaging.datamodel.DatabaseHelper.MessageColumns
+import com.android.messaging.datamodel.DatabaseWrapper
+import com.android.messaging.datamodel.data.MessageData
+import com.android.messaging.mmslib.SqliteWrapper
+import com.android.messaging.mmslib.pdu.PduHeaders
+import com.android.messaging.sms.MmsUtils
+import com.android.messaging.util.LogUtil
+
+internal class IsMmsNotificationDownloadCountSynchronized(
+    private val context: Context,
+    private val database: DatabaseWrapper,
+) {
+
+    operator fun invoke(
+        localCount: Int,
+        remoteCount: Int,
+        localSelection: String,
+        localSelectionArgs: Array<String>?,
+        smsSelection: String,
+        smsSelectionArgs: Array<String>?,
+        mmsSelection: String,
+        mmsSelectionArgs: Array<String>?,
+    ): Boolean {
+        val localSqlSelection = SqlSelection(
+            selection = localSelection,
+            selectionArgs = localSelectionArgs ?: emptyArray(),
+        )
+        val remoteSmsSelection = SqlSelection(
+            selection = smsSelection,
+            selectionArgs = smsSelectionArgs ?: emptyArray(),
+        )
+        val remoteMmsSelection = SqlSelection(
+            selection = mmsSelection,
+            selectionArgs = mmsSelectionArgs ?: emptyArray(),
+        )
+
+        val syncState = when {
+            localCount > 0 -> {
+                getSyncState(
+                    localSelection = localSqlSelection,
+                    remoteMmsSelection = remoteMmsSelection,
+                )
+            }
+
+            else -> SyncState()
+        }
+
+        val ignoredMessageIds = syncState.ignoredMessageIds
+        val adjustedLocalCount = localCount - ignoredMessageIds.size
+        val isInSync = when {
+            syncState.hasRemoteReplacement -> false
+            ignoredMessageIds.isEmpty() -> localCount == remoteCount
+            adjustedLocalCount != remoteCount -> false
+            remoteCount == 0 -> true
+
+            else -> {
+                remainingLocalMessagesMatchRemote(
+                    localSelection = localSqlSelection,
+                    ignoredMessageIds = ignoredMessageIds,
+                    remoteSmsSelection = remoteSmsSelection,
+                    remoteMmsSelection = remoteMmsSelection,
+                )
+            }
+        }
+
+        logMessageCounts(
+            isInSync = isInSync,
+            localCount = localCount,
+            adjustedLocalCount = adjustedLocalCount,
+            ignoredLocalCount = ignoredMessageIds.size,
+            hasRemoteReplacement = syncState.hasRemoteReplacement,
+            remoteCount = remoteCount,
+        )
+
+        return isInSync
+    }
+
+    private fun getSyncState(
+        localSelection: SqlSelection,
+        remoteMmsSelection: SqlSelection,
+    ): SyncState {
+        val localNotifications = queryLocalNotifications(
+            localSelection = localSelection,
+        )
+
+        val existingRemoteMmsIds = queryExistingRemoteMmsIds(
+            remoteMmsIds = collectRemoteMmsIds(
+                localNotifications = localNotifications,
+            ),
+        )
+
+        val missingRemoteNotifications = collectMissingRemoteNotifications(
+            localNotifications = localNotifications,
+            existingRemoteMmsIds = existingRemoteMmsIds,
+        )
+
+        val replacementTransactionIds = queryRemoteReplacementTransactionIds(
+            transactionIds = collectTransactionIds(
+                localNotifications = missingRemoteNotifications,
+            ),
+            remoteMmsSelection = remoteMmsSelection,
+        )
+
+        return resolveSyncState(
+            missingRemoteNotifications = missingRemoteNotifications,
+            replacementTransactionIds = replacementTransactionIds,
+        )
+    }
+
+    private fun resolveSyncState(
+        missingRemoteNotifications: List<LocalNotification>,
+        replacementTransactionIds: Set<String>,
+    ): SyncState {
+        val ignoredMessageIds = mutableListOf<Long>()
+        val nowMillis = System.currentTimeMillis()
+
+        for (notification in missingRemoteNotifications) {
+            val transactionId = notification.transactionId
+            val notificationHasRemoteReplacement = !transactionId.isNullOrEmpty() &&
+                replacementTransactionIds.contains(transactionId)
+
+            when {
+                notificationHasRemoteReplacement -> {
+                    return SyncState(hasRemoteReplacement = true)
+                }
+
+                isMmsNotificationExpired(
+                    mmsExpiry = notification.mmsExpiry,
+                    nowMillis = nowMillis,
+                ) -> {
+                    // Leave it counted so normal sync repair can delete the orphaned row
+                }
+
+                else -> {
+                    ignoredMessageIds.add(notification.messageId)
+                }
+            }
+        }
+
+        return SyncState(ignoredMessageIds = ignoredMessageIds)
+    }
+
+    private fun remainingLocalMessagesMatchRemote(
+        localSelection: SqlSelection,
+        ignoredMessageIds: List<Long>,
+        remoteSmsSelection: SqlSelection,
+        remoteMmsSelection: SqlSelection,
+    ): Boolean {
+        val remoteTimestamps = queryRemoteTimestamps(
+            remoteSmsSelection = remoteSmsSelection,
+            remoteMmsSelection = remoteMmsSelection,
+        )
+
+        val localTimestamps = when {
+            remoteTimestamps == null -> null
+            else -> queryLocalTimestampsExcludingIgnored(
+                localSelection = localSelection,
+                ignoredMessageIds = ignoredMessageIds,
+            )
+        }
+
+        return remoteTimestamps == null ||
+            localTimestamps?.sorted() == remoteTimestamps.sorted()
+    }
+
+    private fun queryRemoteTimestamps(
+        remoteSmsSelection: SqlSelection,
+        remoteMmsSelection: SqlSelection,
+    ): List<Long>? {
+        return try {
+            val smsTimestamps = queryRemoteTimestamps(
+                contentUri = Sms.CONTENT_URI,
+                timestampColumn = Sms.DATE,
+                selection = remoteSmsSelection,
+            )
+            val mmsTimestamps = queryRemoteTimestamps(
+                contentUri = Mms.CONTENT_URI,
+                timestampColumn = Mms.DATE,
+                selection = remoteMmsSelection,
+            )
+
+            when {
+                smsTimestamps == null || mmsTimestamps == null -> null
+                else -> {
+                    smsTimestamps + mmsTimestamps.map { timestamp -> timestamp * 1000L }
+                }
+            }
+        } catch (exception: RuntimeException) {
+            LogUtil.w(TAG, "SyncCursorPair: failed to query remote message timestamps", exception)
+            null
+        }
+    }
+
+    private fun queryRemoteTimestamps(
+        contentUri: Uri,
+        timestampColumn: String,
+        selection: SqlSelection,
+    ): List<Long>? {
+        return SqliteWrapper
+            .query(
+                context,
+                context.contentResolver,
+                contentUri,
+                arrayOf(timestampColumn),
+                selection.selection,
+                selection.selectionArgs,
+                null,
+            )
+            ?.use { cursor ->
+                readTimestamps(cursor = cursor, timestampColumn = timestampColumn)
+            }
+            ?: run {
+                LogUtil.w(TAG, "SyncCursorPair: remote timestamp query returned no cursor")
+                null
+            }
+    }
+
+    private fun queryLocalTimestampsExcludingIgnored(
+        localSelection: SqlSelection,
+        ignoredMessageIds: List<Long>,
+    ): List<Long> {
+        val remainingSelection = localSelection + SqlSelection(
+            selection = "${BaseColumns._ID} NOT IN " +
+                MmsUtils.getSqlInOperand(ignoredMessageIds.size),
+            selectionArgs = Array(ignoredMessageIds.size) { ignoredMessageIds[it].toString() },
+        )
+
+        return database.query(
+            DatabaseHelper.MESSAGES_TABLE,
+            arrayOf(MessageColumns.RECEIVED_TIMESTAMP),
+            remainingSelection.selection,
+            remainingSelection.selectionArgs,
+            null,
+            null,
+            null,
+        ).use { cursor ->
+            readTimestamps(
+                cursor = cursor,
+                timestampColumn = MessageColumns.RECEIVED_TIMESTAMP,
+            )
+        }
+    }
+
+    private fun readTimestamps(cursor: Cursor, timestampColumn: String): List<Long> {
+        val timestampIndex = cursor.getColumnIndexOrThrow(timestampColumn)
+
+        return buildList {
+            while (cursor.moveToNext()) {
+                add(cursor.getLong(timestampIndex))
+            }
+        }
+    }
+
+    private fun logMessageCounts(
+        isInSync: Boolean,
+        localCount: Int,
+        adjustedLocalCount: Int,
+        ignoredLocalCount: Int,
+        hasRemoteReplacement: Boolean,
+        remoteCount: Int,
+    ) {
+        if (isInSync) {
+            if (LogUtil.isLoggable(TAG, LogUtil.DEBUG)) {
+                LogUtil.d(
+                    TAG,
+                    "SyncCursorPair: Same # of local and remote messages = $adjustedLocalCount",
+                )
+            }
+        } else {
+            LogUtil.i(
+                TAG,
+                "SyncCursorPair: Not in sync; # local messages = $localCount" +
+                    ", # ignored local MMS notifications = $ignoredLocalCount" +
+                    ", has remote MMS replacement = $hasRemoteReplacement" +
+                    ", # remote message = $remoteCount",
+            )
+        }
+    }
+
+    private fun queryLocalNotifications(localSelection: SqlSelection): List<LocalNotification> {
+        val notificationSelection = localSelection + SqlSelection(
+            selection = "${MessageColumns.PROTOCOL}=? AND " +
+                "${MessageColumns.STATUS} IN " +
+                mmsNotificationDownloadStatusInOperand,
+            selectionArgs = arrayOf(
+                MessageData.PROTOCOL_MMS_PUSH_NOTIFICATION.toString(),
+                *mmsNotificationDownloadStatusArgs,
+            ),
+        )
+
+        return database.query(
+            DatabaseHelper.MESSAGES_TABLE,
+            arrayOf(
+                BaseColumns._ID,
+                MessageColumns.SMS_MESSAGE_URI,
+                MessageColumns.MMS_TRANSACTION_ID,
+                MessageColumns.MMS_EXPIRY,
+            ),
+            notificationSelection.selection,
+            notificationSelection.selectionArgs,
+            null,
+            null,
+            null,
+        ).use(::readLocalNotifications)
+    }
+
+    private fun queryExistingRemoteMmsIds(remoteMmsIds: Set<Long>): Set<Long>? {
+        if (remoteMmsIds.isEmpty()) {
+            return emptySet()
+        }
+
+        return try {
+            queryRemoteMmsIds(remoteMmsIds = remoteMmsIds)
+        } catch (exception: RuntimeException) {
+            LogUtil.w(TAG, "SyncCursorPair: failed to query remote MMS rows", exception)
+            null
+        }
+    }
+
+    private fun queryRemoteMmsIds(remoteMmsIds: Set<Long>): Set<Long>? {
+        val remoteMmsCursor = SqliteWrapper.query(
+            context,
+            context.contentResolver,
+            Mms.CONTENT_URI,
+            arrayOf(Mms._ID),
+            "${Mms._ID} IN ${MmsUtils.getSqlInOperand(remoteMmsIds.size)}",
+            createRemoteMmsIdSelectionArgs(remoteMmsIds = remoteMmsIds),
+            null,
+        )
+
+        return remoteMmsCursor
+            ?.use(::readRemoteMmsIds)
+            ?: run {
+                LogUtil.w(TAG, "SyncCursorPair: remote MMS row query returned no cursor")
+                null
+            }
+    }
+
+    private fun readRemoteMmsIds(cursor: Cursor): Set<Long> {
+        val remoteMmsIdIndex = cursor.getColumnIndexOrThrow(Mms._ID)
+
+        return buildSet {
+            while (cursor.moveToNext()) {
+                add(cursor.getLong(remoteMmsIdIndex))
+            }
+        }
+    }
+
+    private fun createRemoteMmsIdSelectionArgs(remoteMmsIds: Set<Long>): Array<String> {
+        return remoteMmsIds
+            .map { remoteMmsId -> remoteMmsId.toString() }
+            .toTypedArray()
+    }
+
+    private fun queryRemoteReplacementTransactionIds(
+        transactionIds: Set<String>,
+        remoteMmsSelection: SqlSelection,
+    ): Set<String> {
+        if (transactionIds.isEmpty()) {
+            return emptySet()
+        }
+
+        return try {
+            queryTransactionIds(
+                selection = createRemoteReplacementSelection(
+                    transactionIds = transactionIds,
+                    remoteMmsSelection = remoteMmsSelection,
+                ),
+            )
+        } catch (exception: RuntimeException) {
+            LogUtil.w(
+                TAG,
+                "SyncCursorPair: failed to query remote MMS replacements",
+                exception,
+            )
+            // Retry later instead of forcing a full sync on a transient telephony query failure
+            emptySet()
+        }
+    }
+
+    private fun createRemoteReplacementSelection(
+        transactionIds: Set<String>,
+        remoteMmsSelection: SqlSelection,
+    ): SqlSelection {
+        return remoteMmsSelection + SqlSelection(
+            selection = "${Mms.MESSAGE_BOX}=? AND ${Mms.MESSAGE_TYPE}=? AND " +
+                "${Mms.TRANSACTION_ID} IN " +
+                MmsUtils.getSqlInOperand(transactionIds.size),
+            selectionArgs = arrayOf(
+                Mms.MESSAGE_BOX_INBOX.toString(),
+                PduHeaders.MESSAGE_TYPE_RETRIEVE_CONF.toString(),
+                *transactionIds.toTypedArray(),
+            ),
+        )
+    }
+
+    private fun queryTransactionIds(selection: SqlSelection): Set<String> {
+        return SqliteWrapper
+            .query(
+                context,
+                context.contentResolver,
+                Mms.CONTENT_URI,
+                arrayOf(Mms.TRANSACTION_ID),
+                selection.selection,
+                selection.selectionArgs,
+                null,
+            )
+            ?.use(::readTransactionIds)
+            ?: emptySet()
+    }
+
+    private fun readTransactionIds(cursor: Cursor): Set<String> {
+        val transactionIdIndex = cursor.getColumnIndexOrThrow(Mms.TRANSACTION_ID)
+
+        return buildSet {
+            while (cursor.moveToNext()) {
+                cursor
+                    .getString(transactionIdIndex)
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let(::add)
+            }
+        }
+    }
+
+    private fun readLocalNotifications(cursor: Cursor): List<LocalNotification> {
+        val messageIdIndex = cursor.getColumnIndexOrThrow(BaseColumns._ID)
+        val messageUriIndex = cursor.getColumnIndexOrThrow(MessageColumns.SMS_MESSAGE_URI)
+        val transactionIdIndex = cursor
+            .getColumnIndexOrThrow(MessageColumns.MMS_TRANSACTION_ID)
+        val mmsExpiryIndex = cursor.getColumnIndexOrThrow(MessageColumns.MMS_EXPIRY)
+
+        return buildList {
+            while (cursor.moveToNext()) {
+                add(
+                    LocalNotification(
+                        messageId = cursor.getLong(messageIdIndex),
+                        remoteMmsId = parseRemoteMmsId(
+                            messageUri = cursor.getString(messageUriIndex),
+                        ),
+                        transactionId = cursor.getString(transactionIdIndex),
+                        mmsExpiry = cursor.getLong(mmsExpiryIndex),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun parseRemoteMmsId(messageUri: String?): Long? {
+        return messageUri
+            ?.takeIf { it.isNotEmpty() }
+            ?.toUri()
+            ?.let(MmsUtils::parseRowIdFromMessageUri)
+            ?.takeIf { it >= 0L }
+    }
+
+    private fun collectRemoteMmsIds(localNotifications: List<LocalNotification>): Set<Long> {
+        return localNotifications.mapNotNullTo(destination = LinkedHashSet()) { it.remoteMmsId }
+    }
+
+    private fun collectMissingRemoteNotifications(
+        localNotifications: List<LocalNotification>,
+        existingRemoteMmsIds: Set<Long>?,
+    ): List<LocalNotification> {
+        return localNotifications.filterNot { notification ->
+            remoteMmsMayExist(
+                remoteMmsId = notification.remoteMmsId,
+                existingRemoteMmsIds = existingRemoteMmsIds,
+            )
+        }
+    }
+
+    private fun collectTransactionIds(
+        localNotifications: List<LocalNotification>,
+    ): Set<String> {
+        return localNotifications.mapNotNullTo(destination = LinkedHashSet()) { notification ->
+            notification.transactionId?.takeIf { it.isNotEmpty() }
+        }
+    }
+
+    private fun remoteMmsMayExist(
+        remoteMmsId: Long?,
+        existingRemoteMmsIds: Set<Long>?,
+    ): Boolean {
+        return existingRemoteMmsIds == null ||
+            remoteMmsId == null ||
+            existingRemoteMmsIds.contains(remoteMmsId)
+    }
+
+    private data class SyncState(
+        val ignoredMessageIds: List<Long> = emptyList(),
+        val hasRemoteReplacement: Boolean = false,
+    )
+
+    private class SqlSelection(
+        val selection: String,
+        val selectionArgs: Array<String> = emptyArray(),
+    ) {
+
+        operator fun plus(other: SqlSelection): SqlSelection {
+            return SqlSelection(
+                selection = "($selection) AND (${other.selection})",
+                selectionArgs = selectionArgs + other.selectionArgs,
+            )
+        }
+    }
+
+    private data class LocalNotification(
+        val messageId: Long,
+        val remoteMmsId: Long?,
+        val transactionId: String?,
+        val mmsExpiry: Long,
+    )
+
+    private companion object {
+        private const val TAG = LogUtil.BUGLE_TAG
+    }
+}

--- a/src/com/android/messaging/datamodel/action/mms/MmsNotificationDownloadState.kt
+++ b/src/com/android/messaging/datamodel/action/mms/MmsNotificationDownloadState.kt
@@ -1,0 +1,39 @@
+@file:JvmName("MmsNotificationDownloadState")
+
+package com.android.messaging.datamodel.action.mms
+
+import com.android.messaging.datamodel.data.MessageData
+import com.android.messaging.sms.DatabaseMessages.LocalDatabaseMessage
+import com.android.messaging.sms.MmsUtils
+
+internal val mmsNotificationDownloadStatuses = intArrayOf(
+    MessageData.BUGLE_STATUS_INCOMING_RETRYING_MANUAL_DOWNLOAD,
+    MessageData.BUGLE_STATUS_INCOMING_MANUAL_DOWNLOADING,
+    MessageData.BUGLE_STATUS_INCOMING_RETRYING_AUTO_DOWNLOAD,
+    MessageData.BUGLE_STATUS_INCOMING_AUTO_DOWNLOADING,
+)
+
+internal val mmsNotificationDownloadStatusArgs = Array(mmsNotificationDownloadStatuses.size) {
+    mmsNotificationDownloadStatuses[it].toString()
+}
+
+internal val mmsNotificationDownloadStatusInOperand = MmsUtils
+    .getSqlInOperand(mmsNotificationDownloadStatuses.size)
+
+internal fun shouldProtectMmsNotificationDownload(
+    localMessage: LocalDatabaseMessage,
+): Boolean {
+    return MessageData.getIsMmsNotification(localMessage.protocol) &&
+        mmsNotificationDownloadStatuses.contains(localMessage.status) &&
+        !isMmsNotificationExpired(
+            mmsExpiry = localMessage.mmsExpiry,
+            nowMillis = System.currentTimeMillis(),
+        )
+}
+
+internal fun isMmsNotificationExpired(
+    mmsExpiry: Long,
+    nowMillis: Long,
+): Boolean {
+    return mmsExpiry in 1..nowMillis
+}

--- a/src/com/android/messaging/sms/DatabaseMessages.java
+++ b/src/com/android/messaging/sms/DatabaseMessages.java
@@ -854,14 +854,19 @@ public class DatabaseMessages {
         private final long mTimestamp;
         private final long mLocalId;
         private final String mConversationId;
+        private final int mStatus;
+        private final long mMmsExpiry;
 
         public LocalDatabaseMessage(final long localId, final int protocol, final String uri,
-                final long timestamp, final String conversationId) {
+                final long timestamp, final String conversationId, final int status,
+                final long mmsExpiry) {
             mLocalId = localId;
             mProtocol = protocol;
             mUri = uri;
             mTimestamp = timestamp;
             mConversationId = conversationId;
+            mStatus = status;
+            mMmsExpiry = mmsExpiry;
         }
 
         @Override
@@ -887,6 +892,14 @@ public class DatabaseMessages {
             return mConversationId;
         }
 
+        public int getStatus() {
+            return mStatus;
+        }
+
+        public long getMmsExpiry() {
+            return mMmsExpiry;
+        }
+
         @Override
         public int describeContents() {
             return 0;
@@ -898,6 +911,8 @@ public class DatabaseMessages {
             mLocalId = in.readLong();
             mTimestamp = in.readLong();
             mProtocol = in.readInt();
+            mStatus = in.readInt();
+            mMmsExpiry = in.readLong();
         }
 
         public static final Parcelable.Creator<LocalDatabaseMessage> CREATOR
@@ -920,6 +935,8 @@ public class DatabaseMessages {
             out.writeLong(mLocalId);
             out.writeLong(mTimestamp);
             out.writeInt(mProtocol);
+            out.writeInt(mStatus);
+            out.writeLong(mMmsExpiry);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/GrapheneOS/Messaging/issues/144

The app can temporarily have a local MMS download notification while Android’s telephony provider has already replaced the original remote notification row with the downloaded MMS row.

Before this fix, sync did not treat those two rows as the same MMS lifecycle step. Depending on timing, it could either delete the local "tap to download" notification because its original remote row was gone, or later decide the older message range was synchronized because the local and remote row counts matched. In both cases, the downloaded MMS was not reliably reconciled with the local notification, which could make the message appear to disappear or remain stuck as a download placeholder.

The fix teaches sync to recognize the notification-to-downloaded-MMS replacement case and update the local notification row into the downloaded MMS instead of deleting it or treating the mismatch as already synchronized.