### PR TITLE
Change hardcoded colors to more neutral, and add some basic color schemes

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -15,12 +15,12 @@
     limitations under the License.
 -->
 <resources>
-    <color name="primary_color">#689F38</color>
+    <color name="primary_color">#616161</color>
 
     <!--  Action bar -->
     <color name="action_bar_title_text_color">#ffffff</color>
     <color name="action_bar_background_color">@color/primary_color</color>
-    <color name="action_bar_background_color_dark">#537F2D</color>
+    <color name="action_bar_background_color_dark">#424242</color>
     <color name="contextual_action_bar_background_color">#ffffff</color>
     <color name="archived_conversation_action_bar_background_color">#9D9D9D</color>
     <color name="archived_conversation_action_bar_background_color_dark">#838383</color>
@@ -64,8 +64,8 @@
     <color name="message_bubble_color_outgoing">#ffffffff</color>
     <color name="message_error_bubble_color_incoming">#e2e2e2</color>
     <color name="message_audio_button_color_incoming">#ffffffff</color>
-    <color name="message_bubble_color_selected">#8BC34A</color>
-    <color name="message_image_selected_tint">#80689F38</color>
+    <color name="message_bubble_color_selected">#757575</color>
+    <color name="message_image_selected_tint">#80616161</color>
     <color name="generic_video_icon">#ff808080</color>
 
     <!-- Base color used for color filtering. -->
@@ -110,7 +110,7 @@
     <color name="sim_indicator_color_light">#ffffff</color>
     <color name="sim_indicator_color_dark">#323232</color>
 
-    <color name="text_highlight_color">#80689F38</color>
+    <color name="text_highlight_color">#80616161</color>
     <color name="search_view_text_cursor">#b0dddddd</color>
 
     <color name="button_bar_action_button_text_color">#03a9f4</color>

--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -30,6 +30,7 @@
     <string name="sms_enabled_pref_key" translatable="false">sms_enabled</string>
     <string name="send_sound_pref_key" translatable="false">send_sound</string>
     <bool name="send_sound_pref_default" translatable="false">true</bool>
+    <string name="color_scheme_pref_key" translatable="false">color_scheme</string>
     <string name="advanced_pref_key" translatable="false">advanced_prefs</string>
 
     <!-- Subscription-specific settings. The values of these pref keys must be prefixed with

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -502,6 +502,20 @@
     <!-- Title for the preference for playing a message send sound -->
     <string name="send_sound_pref_title">Outgoing message sounds</string>
 
+    <!-- Title for the preference for choosing the app's color scheme -->
+    <string name="color_scheme_pref_title">Color scheme</string>
+    <!-- Notice shown in the color scheme dialog explaining when the change takes effect -->
+    <string name="color_scheme_pref_restart_notice">Applies after restarting the app</string>
+    <!-- Color scheme options -->
+    <string name="color_scheme_dynamic">Dynamic</string>
+    <string name="color_scheme_green">Green</string>
+    <string name="color_scheme_gray">Gray</string>
+    <string name="color_scheme_blue">Blue</string>
+    <string name="color_scheme_dark_blue">Dark blue</string>
+    <string name="color_scheme_purple">Purple</string>
+    <string name="color_scheme_violet">Violet</string>
+    <string name="color_scheme_teal">Teal</string>
+
     <string name="dump_sms_pref_title">Dump SMS</string>
     <string name="dump_sms_pref_summary">Dump received SMS raw data into external storage file</string>
     <string name="dump_mms_pref_title">Dump MMS</string>

--- a/src/com/android/messaging/data/appsettings/model/AppColorScheme.kt
+++ b/src/com/android/messaging/data/appsettings/model/AppColorScheme.kt
@@ -1,0 +1,23 @@
+package com.android.messaging.data.appsettings.model
+
+import androidx.annotation.StringRes
+import com.android.messaging.R
+
+internal enum class AppColorScheme(
+    @param:StringRes val titleResId: Int,
+) {
+    DYNAMIC(R.string.color_scheme_dynamic),
+    GREEN(R.string.color_scheme_green),
+    GRAY(R.string.color_scheme_gray),
+    BLUE(R.string.color_scheme_blue),
+    DARK_BLUE(R.string.color_scheme_dark_blue),
+    PURPLE(R.string.color_scheme_purple),
+    VIOLET(R.string.color_scheme_violet),
+    TEAL(R.string.color_scheme_teal),
+    ;
+
+    companion object {
+        fun fromPrefValue(value: String?): AppColorScheme =
+            entries.firstOrNull { it.name == value } ?: DYNAMIC
+    }
+}

--- a/src/com/android/messaging/data/appsettings/model/AppSettings.kt
+++ b/src/com/android/messaging/data/appsettings/model/AppSettings.kt
@@ -7,4 +7,5 @@ internal data class AppSettings(
     val isDebugEnabled: Boolean,
     val dumpSmsEnabled: Boolean,
     val dumpMmsEnabled: Boolean,
+    val colorScheme: AppColorScheme,
 )

--- a/src/com/android/messaging/data/appsettings/repository/AppSettingsRepository.kt
+++ b/src/com/android/messaging/data/appsettings/repository/AppSettingsRepository.kt
@@ -3,6 +3,7 @@ package com.android.messaging.data.appsettings.repository
 import android.content.Context
 import com.android.messaging.R
 import com.android.messaging.data.appsettings.model.AppBooleanPref
+import com.android.messaging.data.appsettings.model.AppColorScheme
 import com.android.messaging.data.appsettings.model.AppSettings
 import com.android.messaging.di.core.IoDispatcher
 import com.android.messaging.util.BuglePrefs
@@ -16,6 +17,7 @@ import kotlinx.coroutines.withContext
 internal interface AppSettingsRepository {
     suspend fun getAppSettings(): AppSettings
     suspend fun setBooleanPref(pref: AppBooleanPref, enabled: Boolean)
+    suspend fun setColorScheme(colorScheme: AppColorScheme)
 }
 
 internal class AppSettingsRepositoryImpl @Inject constructor(
@@ -45,6 +47,9 @@ internal class AppSettingsRepositoryImpl @Inject constructor(
                     context.getString(R.string.dump_mms_pref_key),
                     resources.getBoolean(R.bool.dump_mms_pref_default),
                 ),
+                colorScheme = AppColorScheme.fromPrefValue(
+                    appPrefs.getString(context.getString(R.string.color_scheme_pref_key), null),
+                ),
             )
         }
     }
@@ -57,6 +62,15 @@ internal class AppSettingsRepositoryImpl @Inject constructor(
             BuglePrefs.getApplicationPrefs().putBoolean(
                 context.getString(pref.keyResId),
                 enabled,
+            )
+        }
+    }
+
+    override suspend fun setColorScheme(colorScheme: AppColorScheme) {
+        withContext(ioDispatcher) {
+            BuglePrefs.getApplicationPrefs().putString(
+                context.getString(R.string.color_scheme_pref_key),
+                colorScheme.name,
             )
         }
     }

--- a/src/com/android/messaging/ui/appsettings/general/delegate/AppSettingsDelegate.kt
+++ b/src/com/android/messaging/ui/appsettings/general/delegate/AppSettingsDelegate.kt
@@ -1,6 +1,7 @@
 package com.android.messaging.ui.appsettings.general.delegate
 
 import com.android.messaging.data.appsettings.model.AppBooleanPref
+import com.android.messaging.data.appsettings.model.AppColorScheme
 import com.android.messaging.data.appsettings.repository.AppSettingsRepository
 import com.android.messaging.ui.appsettings.common.SettingsScreenDelegate
 import com.android.messaging.ui.appsettings.general.mapper.AppSettingsUiStateMapper
@@ -20,6 +21,7 @@ internal interface AppSettingsDelegate : SettingsScreenDelegate<AppSettingsUiSta
     fun onSendSoundChanged(enabled: Boolean)
     fun onDumpSmsChanged(enabled: Boolean)
     fun onDumpMmsChanged(enabled: Boolean)
+    fun onColorSchemeChanged(colorScheme: AppColorScheme)
 }
 
 internal class AppSettingsDelegateImpl @Inject constructor(
@@ -75,6 +77,13 @@ internal class AppSettingsDelegateImpl @Inject constructor(
             pref = AppBooleanPref.DUMP_MMS,
             enabled = enabled,
         )
+    }
+
+    override fun onColorSchemeChanged(colorScheme: AppColorScheme) {
+        boundScope?.launch {
+            repository.setColorScheme(colorScheme)
+            refresh()
+        }
     }
 
     private fun setBooleanPref(

--- a/src/com/android/messaging/ui/appsettings/general/mapper/AppSettingsUiStateMapper.kt
+++ b/src/com/android/messaging/ui/appsettings/general/mapper/AppSettingsUiStateMapper.kt
@@ -26,6 +26,7 @@ internal class AppSettingsUiStateMapperImpl @Inject constructor(
             isDebugEnabled = appSettings.isDebugEnabled,
             dumpSmsEnabled = appSettings.dumpSmsEnabled,
             dumpMmsEnabled = appSettings.dumpMmsEnabled,
+            colorScheme = appSettings.colorScheme,
         )
     }
 }

--- a/src/com/android/messaging/ui/appsettings/general/model/AppSettingsUiState.kt
+++ b/src/com/android/messaging/ui/appsettings/general/model/AppSettingsUiState.kt
@@ -1,6 +1,7 @@
 package com.android.messaging.ui.appsettings.general.model
 
 import androidx.compose.runtime.Immutable
+import com.android.messaging.data.appsettings.model.AppColorScheme
 
 @Immutable
 internal data class AppSettingsUiState(
@@ -10,4 +11,5 @@ internal data class AppSettingsUiState(
     val isDebugEnabled: Boolean = false,
     val dumpSmsEnabled: Boolean = false,
     val dumpMmsEnabled: Boolean = false,
+    val colorScheme: AppColorScheme = AppColorScheme.DYNAMIC,
 )

--- a/src/com/android/messaging/ui/appsettings/general/ui/AppSettingsScreen.kt
+++ b/src/com/android/messaging/ui/appsettings/general/ui/AppSettingsScreen.kt
@@ -1,19 +1,40 @@
 package com.android.messaging.ui.appsettings.general.ui
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import com.android.messaging.R
+import com.android.messaging.data.appsettings.model.AppColorScheme
 import com.android.messaging.ui.appsettings.common.SettingsCategoryHeader
 import com.android.messaging.ui.appsettings.common.SettingsClickableItem
 import com.android.messaging.ui.appsettings.common.SettingsSwitchItem
@@ -33,6 +54,7 @@ internal fun AppSettingsScreen(
     onAdvancedClick: (() -> Unit)? = null,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    var showColorSchemeDialog by remember { mutableStateOf(false) }
     val title = if (isTopLevel) {
         stringResource(R.string.settings_activity_title)
     } else {
@@ -56,6 +78,7 @@ internal fun AppSettingsScreen(
             coreSettingsItems(
                 appSettings = appSettings,
                 onAction = onAction,
+                onColorSchemeClick = { showColorSchemeDialog = true },
             )
 
             if (isTopLevel && onAdvancedClick != null) {
@@ -70,11 +93,23 @@ internal fun AppSettingsScreen(
             licenseSettingsItems(onAction)
         }
     }
+
+    if (showColorSchemeDialog) {
+        ColorSchemeDialog(
+            selected = appSettings.colorScheme,
+            onDismiss = { showColorSchemeDialog = false },
+            onConfirm = { colorScheme ->
+                onAction(Action.ColorSchemeChanged(colorScheme))
+                showColorSchemeDialog = false
+            },
+        )
+    }
 }
 
 private fun LazyListScope.coreSettingsItems(
     appSettings: AppSettingsUiState,
     onAction: (Action) -> Unit,
+    onColorSchemeClick: () -> Unit,
 ) {
     item(key = "default_sms_app") {
         SettingsClickableItem(
@@ -102,6 +137,14 @@ private fun LazyListScope.coreSettingsItems(
             onCheckedChange = {
                 onAction(Action.SendSoundChanged(it))
             },
+        )
+    }
+
+    item(key = "color_scheme") {
+        SettingsClickableItem(
+            title = stringResource(R.string.color_scheme_pref_title),
+            summary = stringResource(appSettings.colorScheme.titleResId),
+            onClick = onColorSchemeClick,
         )
     }
 }
@@ -163,6 +206,92 @@ private fun LazyListScope.licenseSettingsItems(
             onClick = {
                 onAction(Action.LicensesClicked)
             },
+        )
+    }
+}
+
+@Composable
+private fun ColorSchemeDialog(
+    selected: AppColorScheme,
+    onDismiss: () -> Unit,
+    onConfirm: (AppColorScheme) -> Unit,
+) {
+    var selectedScheme by remember { mutableStateOf(selected) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = stringResource(R.string.color_scheme_pref_title))
+        },
+        text = {
+            Column {
+                Text(
+                    text = stringResource(R.string.color_scheme_pref_restart_notice),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Column(modifier = Modifier.selectableGroup()) {
+                    AppColorScheme.entries.forEach { scheme ->
+                        ColorSchemeOption(
+                            text = stringResource(scheme.titleResId),
+                            selected = scheme == selectedScheme,
+                            onClick = { selectedScheme = scheme },
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selectedScheme) }) {
+                Text(text = stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(android.R.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun ColorSchemeOption(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                onClick = onClick,
+                role = Role.RadioButton,
+            )
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = null,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ColorSchemeDialogPreview() {
+    MessagingPreviewTheme {
+        ColorSchemeDialog(
+            selected = AppColorScheme.DYNAMIC,
+            onDismiss = {},
+            onConfirm = {},
         )
     }
 }

--- a/src/com/android/messaging/ui/appsettings/screen/SettingsViewModel.kt
+++ b/src/com/android/messaging/ui/appsettings/screen/SettingsViewModel.kt
@@ -71,74 +71,45 @@ internal class SettingsViewModel @Inject constructor(
 
     override fun onAction(action: Action) {
         when (action) {
-            is Action.AutoRetrieveMmsChanged -> {
-                subscriptionSettingsDelegate.onAutoRetrieveMmsChanged(
-                    subId = action.subId,
-                    enabled = action.enabled,
-                )
-            }
+            is Action.AutoRetrieveMmsChanged ->
+                subscriptionSettingsDelegate.onAutoRetrieveMmsChanged(action.subId, action.enabled)
 
-            is Action.AutoRetrieveMmsWhenRoamingChanged -> {
+            is Action.AutoRetrieveMmsWhenRoamingChanged ->
                 subscriptionSettingsDelegate.onAutoRetrieveMmsWhenRoamingChanged(
                     subId = action.subId,
                     enabled = action.enabled,
                 )
-            }
 
-            is Action.DeliveryReportsChanged -> {
-                subscriptionSettingsDelegate.onDeliveryReportsChanged(
-                    subId = action.subId,
-                    enabled = action.enabled,
-                )
-            }
+            is Action.DeliveryReportsChanged ->
+                subscriptionSettingsDelegate.onDeliveryReportsChanged(action.subId, action.enabled)
 
-            is Action.GroupMmsChanged -> {
-                subscriptionSettingsDelegate.onGroupMmsChanged(
-                    subId = action.subId,
-                    enabled = action.enabled,
-                )
-            }
+            is Action.GroupMmsChanged ->
+                subscriptionSettingsDelegate.onGroupMmsChanged(action.subId, action.enabled)
 
-            is Action.PhoneNumberChanged -> {
-                subscriptionSettingsDelegate.onPhoneNumberChanged(
-                    subId = action.subId,
-                    phoneNumber = action.phoneNumber,
-                )
-            }
+            is Action.PhoneNumberChanged ->
+                subscriptionSettingsDelegate.onPhoneNumberChanged(action.subId, action.phoneNumber)
 
-            is Action.WirelessAlertsClicked -> {
-                emitEffect(Effect.OpenWirelessAlerts(action.subId))
-            }
+            is Action.WirelessAlertsClicked -> emitEffect(Effect.OpenWirelessAlerts(action.subId))
+            is Action.DumpMmsChanged -> appSettingsDelegate.onDumpMmsChanged(action.enabled)
+            is Action.DumpSmsChanged -> appSettingsDelegate.onDumpSmsChanged(action.enabled)
+            is Action.SendSoundChanged -> appSettingsDelegate.onSendSoundChanged(action.enabled)
 
-            is Action.DumpMmsChanged -> {
-                appSettingsDelegate.onDumpMmsChanged(action.enabled)
-            }
+            is Action.ColorSchemeChanged ->
+                appSettingsDelegate.onColorSchemeChanged(action.colorScheme)
 
-            is Action.DumpSmsChanged -> {
-                appSettingsDelegate.onDumpSmsChanged(action.enabled)
-            }
-
-            is Action.SendSoundChanged -> {
-                appSettingsDelegate.onSendSoundChanged(action.enabled)
-            }
-
-            is Action.DefaultSmsAppClicked -> {
-                val effect = if (action.isCurrentlyDefault) {
-                    Effect.OpenManageDefaultApps
-                } else {
-                    Effect.RequestDefaultSmsApp
-                }
-                emitEffect(effect)
-            }
-
-            is Action.NotificationsClicked -> {
-                emitEffect(Effect.OpenNotificationSettings)
-            }
-
-            is Action.LicensesClicked -> {
-                emitEffect(Effect.OpenLicenses)
-            }
+            is Action.DefaultSmsAppClicked -> onDefaultSmsAppClicked(action.isCurrentlyDefault)
+            is Action.NotificationsClicked -> emitEffect(Effect.OpenNotificationSettings)
+            is Action.LicensesClicked -> emitEffect(Effect.OpenLicenses)
         }
+    }
+
+    private fun onDefaultSmsAppClicked(isCurrentlyDefault: Boolean) {
+        val effect = if (isCurrentlyDefault) {
+            Effect.OpenManageDefaultApps
+        } else {
+            Effect.RequestDefaultSmsApp
+        }
+        emitEffect(effect)
     }
 
     private fun emitEffect(effect: Effect) {

--- a/src/com/android/messaging/ui/appsettings/screen/model/SettingsAction.kt
+++ b/src/com/android/messaging/ui/appsettings/screen/model/SettingsAction.kt
@@ -1,5 +1,7 @@
 package com.android.messaging.ui.appsettings.screen.model
 
+import com.android.messaging.data.appsettings.model.AppColorScheme
+
 internal sealed interface SettingsAction {
 
     data class AutoRetrieveMmsChanged(
@@ -41,6 +43,10 @@ internal sealed interface SettingsAction {
 
     data class SendSoundChanged(
         val enabled: Boolean,
+    ) : SettingsAction
+
+    data class ColorSchemeChanged(
+        val colorScheme: AppColorScheme,
     ) : SettingsAction
 
     data class DefaultSmsAppClicked(

--- a/src/com/android/messaging/ui/core/Theme.kt
+++ b/src/com/android/messaging/ui/core/Theme.kt
@@ -1,14 +1,24 @@
 package com.android.messaging.ui.core
 
+import android.content.Context
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
+import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.android.messaging.R
+import com.android.messaging.data.appsettings.model.AppColorScheme
+import com.android.messaging.util.BuglePrefs
 
 private val AppShapes = Shapes(
     extraSmall = RoundedCornerShape(size = 12.dp),
@@ -18,14 +28,47 @@ private val AppShapes = Shapes(
     extraLarge = RoundedCornerShape(size = 36.dp),
 )
 
+private val ColorSchemeSeeds = mapOf(
+    AppColorScheme.GREEN to Color(0xFF689F38),
+    AppColorScheme.GRAY to Color(0xFF616161),
+    AppColorScheme.BLUE to Color(0xFF1976D2),
+    AppColorScheme.DARK_BLUE to Color(0xFF0D47A1),
+    AppColorScheme.PURPLE to Color(0xFF8E24AA),
+    AppColorScheme.VIOLET to Color(0xFF5E35B1),
+    AppColorScheme.TEAL to Color(0xFF00695C),
+)
+
 @Composable
 fun AppTheme(
     content: @Composable () -> Unit,
 ) {
     val context = LocalContext.current
+    val isDark = isSystemInDarkTheme()
+    val appColorScheme = rememberAppColorScheme(context)
+    val seed = ColorSchemeSeeds[appColorScheme]
     val colorScheme = when {
-        isSystemInDarkTheme() -> dynamicDarkColorScheme(context = context)
-        else -> dynamicLightColorScheme(context = context)
+        seed == null -> if (isDark) {
+            dynamicDarkColorScheme(context = context)
+        } else {
+            dynamicLightColorScheme(context = context)
+        }
+
+        else -> {
+            val base = if (isDark) darkColorScheme() else lightColorScheme()
+            val onSeed = if (seed.luminance() > 0.5f) Color.Black else Color.White
+            val container = lerp(
+                start = seed,
+                stop = if (isDark) Color.Black else Color.White,
+                fraction = if (isDark) 0.6f else 0.8f,
+            )
+            val onContainer = if (container.luminance() > 0.5f) Color.Black else Color.White
+            base.copy(
+                primary = seed,
+                onPrimary = onSeed,
+                primaryContainer = container,
+                onPrimaryContainer = onContainer,
+            )
+        }
     }
 
     MaterialTheme(
@@ -33,4 +76,14 @@ fun AppTheme(
         shapes = AppShapes,
         content = content,
     )
+}
+
+@Composable
+private fun rememberAppColorScheme(context: Context): AppColorScheme = remember {
+    val prefs = context.getSharedPreferences(
+        BuglePrefs.SHARED_PREFERENCES_NAME,
+        Context.MODE_PRIVATE,
+    )
+    val colorSchemeKey = context.getString(R.string.color_scheme_pref_key)
+    AppColorScheme.fromPrefValue(prefs.getString(colorSchemeKey, null))
 }


### PR DESCRIPTION
Hello, first off, a big thanks for the GrapheneOS project.  I am hoping you will consider this PR, or consider a similar/better implementation.  The default color scheme in the Messaging app for incoming messages has white text on green background.  Green and white is a fairly common color blindness - for me it is difficult to read incoming messages.  There are other messaging and SMS apps available, but unfortunately I haven't found an SMS app that works reliably in secondary profiles (well known issues).  

This changes the old green defaults to grays, and provides a few color schemes which, while not designer quality, do seem to be easier to read.

Thank you!