### PR TITLE
Fix appearance animation scroll-state recomposition

### DIFF
--- a/app/src/androidTest/java/com/android/messaging/ui/conversationlist/ui/support/ConversationAppearanceAnimationTest.kt
+++ b/app/src/androidTest/java/com/android/messaging/ui/conversationlist/ui/support/ConversationAppearanceAnimationTest.kt
@@ -1,0 +1,178 @@
+package com.android.messaging.ui.conversationlist.ui.support
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.unit.dp
+import com.android.messaging.ui.conversationlist.model.ConversationListItemUiModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toImmutableList
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+internal class ConversationAppearanceAnimationTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun scrollPositionChange_doesNotRecomposeAppearanceTokenProbe() {
+        val conversationItems = previewConversationListItems()
+        var probeCompositions = 0
+        lateinit var listState: LazyListState
+
+        composeRule.setContent {
+            listState = rememberLazyListState()
+
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.height(96.dp),
+            ) {
+                items(items = (0 until 50).toList()) { index ->
+                    BasicText(
+                        text = "row $index",
+                        modifier = Modifier.height(48.dp),
+                    )
+                }
+            }
+
+            AppearanceTokenProbe(
+                items = conversationItems,
+                listState = listState,
+                excludedConversationIds = persistentSetOf(),
+                onComposed = {
+                    probeCompositions += 1
+                },
+            )
+        }
+
+        composeRule.waitForIdle()
+        val afterInitialComposition = probeCompositions
+
+        composeRule.runOnIdle {
+            listState.requestScrollToItem(index = 0, scrollOffset = 24)
+        }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle {
+            assertEquals(24, listState.firstVisibleItemScrollOffset)
+            assertEquals(afterInitialComposition, probeCompositions)
+        }
+    }
+
+    @Test
+    fun appearanceTokenHolder_unrelatedRecomposition_returnsSameInstance() {
+        val tick = mutableIntStateOf(0)
+        val seenTokens = mutableListOf<AppearanceAnimationTokens>()
+        var latestSeenTick = -1
+
+        composeRule.setContent {
+            val listState = rememberLazyListState()
+            val currentTick = tick.intValue
+            val tokens = rememberAppearanceAnimationTokens(
+                items = previewConversationListItems(),
+                listState = listState,
+                excludedConversationIds = persistentSetOf(),
+            )
+
+            SideEffect {
+                latestSeenTick = currentTick
+                seenTokens += tokens
+            }
+        }
+
+        composeRule.waitForIdle()
+        val initialTokens = seenTokens.last()
+        val sizeBeforeTick = seenTokens.size
+
+        composeRule.runOnIdle {
+            tick.intValue += 1
+        }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle {
+            assertEquals(1, latestSeenTick)
+            assertTrue(seenTokens.size > sizeBeforeTick)
+            assertSame(initialTokens, seenTokens.last())
+        }
+    }
+
+    @Test
+    fun newConversationAtTop_insertionComposition_getsToken() {
+        val newConversationId = "new"
+        val initialItems = previewConversationListItems()
+        val itemsState = mutableStateOf(initialItems)
+        val newConversationTokens = mutableListOf<AppearanceAnimationToken?>()
+
+        composeRule.setContent {
+            val listState = rememberLazyListState()
+            val tokens = rememberAppearanceAnimationTokens(
+                items = itemsState.value,
+                listState = listState,
+                excludedConversationIds = persistentSetOf(),
+            )
+            val newConversationToken = tokens.tokenFor(newConversationId)
+
+            SideEffect {
+                newConversationTokens += newConversationToken
+            }
+        }
+
+        composeRule.waitForIdle()
+        val recordsBeforeInsertion = newConversationTokens.size
+        composeRule.runOnIdle {
+            assertNull(newConversationTokens.last())
+        }
+
+        composeRule.runOnIdle {
+            val newItem = previewConversationListItem(
+                conversationId = newConversationId,
+                title = "New conversation",
+                snippetText = "New message",
+            )
+            itemsState.value = (listOf(newItem) + initialItems).toImmutableList()
+        }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle {
+            // Check the first composition after insertion. A later tracker update could
+            // hide stale enteringTokens from an over-broad remember key.
+            assertTrue(newConversationTokens.size > recordsBeforeInsertion)
+            assertNotNull(newConversationTokens[recordsBeforeInsertion])
+        }
+    }
+
+    @Composable
+    private fun AppearanceTokenProbe(
+        items: ImmutableList<ConversationListItemUiModel>,
+        listState: LazyListState,
+        excludedConversationIds: ImmutableSet<String>,
+        onComposed: () -> Unit,
+    ) {
+        rememberAppearanceAnimationTokens(
+            items = items,
+            listState = listState,
+            excludedConversationIds = excludedConversationIds,
+        )
+
+        SideEffect {
+            onComposed()
+        }
+    }
+}

--- a/src/com/android/messaging/ui/conversationlist/ui/support/ConversationAppearanceAnimation.kt
+++ b/src/com/android/messaging/ui/conversationlist/ui/support/ConversationAppearanceAnimation.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.Snapshot
 import com.android.messaging.ui.conversationlist.model.ConversationListItemUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
@@ -100,8 +101,13 @@ internal fun rememberAppearanceAnimationTokens(
         items.mapTo(HashSet(items.size), ConversationListItemUiModel::conversationId)
     }
     val enteringTokens = remember(currentConversationIds, excludedConversationIds) {
-        val isListAtTop = listState.firstVisibleItemIndex == 0 &&
-            listState.firstVisibleItemScrollOffset == 0
+        // LazyListState warns these values are observable and frequently changing.
+        // Sample them only when the id set changes: new rows animate only if the
+        // list is already at the top, and scrolling alone should not invalidate this.
+        val isListAtTop = Snapshot.withoutReadObservation {
+            listState.firstVisibleItemIndex == 0 &&
+                listState.firstVisibleItemScrollOffset == 0
+        }
 
         tracker.computeEntering(
             currentConversationIds = currentConversationIds,
@@ -117,8 +123,10 @@ internal fun rememberAppearanceAnimationTokens(
         )
     }
 
-    return AppearanceAnimationTokens(
-        tracker = tracker,
-        enteringTokens = enteringTokens,
-    )
+    return remember(enteringTokens) {
+        AppearanceAnimationTokens(
+            tracker = tracker,
+            enteringTokens = enteringTokens,
+        )
+    }
 }


### PR DESCRIPTION
Closes #190 

This was causing all ConversationListRows / SwipeableConversationListItems in the LazyColumn of ConversationListContent to recompose even when only 1 conversation changes (e.g. mark the top conversation as read/unread and observe recomposition counts going up in Android Studio's Layout Inspector (under Running Devices tab).