### PR TITLE
Fix crash when declining a call with a quick response

### DIFF
--- a/app/src/test/kotlin/com/android/messaging/datamodel/NoConfirmationSmsSendServiceRespondViaMessageTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/datamodel/NoConfirmationSmsSendServiceRespondViaMessageTest.kt
@@ -1,0 +1,101 @@
+package com.android.messaging.datamodel
+
+import android.content.Intent
+import android.net.Uri
+import android.telephony.TelephonyManager
+import com.android.messaging.FactoryTestAccess
+import com.android.messaging.datamodel.action.InsertNewMessageAction
+import com.android.messaging.datamodel.data.MessageData
+import com.android.messaging.datamodel.data.ParticipantData
+import com.android.messaging.testutil.installTestFactory
+import com.android.messaging.ui.UIIntents
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class NoConfirmationSmsSendServiceRespondViaMessageTest {
+
+    @Before
+    fun setUp() {
+        installTestFactory(
+            context = RuntimeEnvironment.getApplication().applicationContext,
+        )
+        mockkStatic(InsertNewMessageAction::class)
+        every {
+            InsertNewMessageAction.insertNewMessage(any(), any(), any(), any())
+        } just runs
+        every { InsertNewMessageAction.insertNewMessage(any()) } just runs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        FactoryTestAccess.reset()
+    }
+
+    @Test
+    fun respondViaMessageWithoutConversationSendsReplyWithoutNotificationUpdate() {
+        val intent = respondViaMessageIntent()
+
+        TestNoConfirmationSmsSendService().handle(intent)
+
+        verify(exactly = 1) {
+            InsertNewMessageAction.insertNewMessage(
+                ParticipantData.DEFAULT_SELF_SUB_ID,
+                RECIPIENT,
+                REPLY_TEXT,
+                null,
+            )
+        }
+    }
+
+    @Test
+    fun respondViaMessageWithConversationStillUpdatesNotificationInlineReply() {
+        mockkStatic(BugleNotifications::class)
+        every { BugleNotifications.updateWithInlineReply(any(), any()) } just runs
+        val intent = respondViaMessageIntent().putExtra(
+            UIIntents.UI_INTENT_EXTRA_CONVERSATION_ID,
+            CONVERSATION_ID,
+        )
+
+        TestNoConfirmationSmsSendService().handle(intent)
+
+        val message = slot<MessageData>()
+        verify(exactly = 1) { InsertNewMessageAction.insertNewMessage(capture(message)) }
+        assertEquals(CONVERSATION_ID, message.captured.conversationId)
+        verify(exactly = 1) {
+            BugleNotifications.updateWithInlineReply(CONVERSATION_ID, REPLY_TEXT)
+        }
+    }
+
+    private fun respondViaMessageIntent(): Intent {
+        return Intent(
+            TelephonyManager.ACTION_RESPOND_VIA_MESSAGE,
+            Uri.parse("smsto:$RECIPIENT"),
+        ).putExtra(Intent.EXTRA_TEXT, REPLY_TEXT)
+    }
+
+    private class TestNoConfirmationSmsSendService : NoConfirmationSmsSendService() {
+        fun handle(intent: Intent) {
+            onHandleIntent(intent)
+        }
+    }
+
+    private companion object {
+        private const val RECIPIENT = "+15551234567"
+        private const val REPLY_TEXT = "Can't talk right now, what's up?"
+        private const val CONVERSATION_ID = "194"
+    }
+}

--- a/src/com/android/messaging/datamodel/NoConfirmationSmsSendService.java
+++ b/src/com/android/messaging/datamodel/NoConfirmationSmsSendService.java
@@ -25,7 +25,6 @@ import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 
 import com.android.messaging.datamodel.action.InsertNewMessageAction;
-import com.android.messaging.datamodel.action.UpdateMessageNotificationAction;
 import com.android.messaging.datamodel.data.MessageData;
 import com.android.messaging.datamodel.data.ParticipantData;
 import com.android.messaging.ui.UIIntents;
@@ -126,8 +125,8 @@ public class NoConfirmationSmsSendService extends IntentService {
                             message);
                 }
                 InsertNewMessageAction.insertNewMessage(messageData);
+                BugleNotifications.updateWithInlineReply(conversationId, message);
             }
-            BugleNotifications.updateWithInlineReply(conversationId, message);
         }
     }
 


### PR DESCRIPTION
Commit 9aec6f6b replaced the argument-less notification refresh with BugleNotifications.updateWithInlineReply(conversationId, message), which is also reached from the recipients-only RESPOND_VIA_MESSAGE path where conversationId is null. Telecom invokes this exported service whenever the user rejects an incoming call with a quick-response text, and the null conversationId crashes on the non-null channelId parameter of NotificationChannelUtil.getActiveNotification. Since the service sets intent redelivery, the crash also redelivers the intent and re-sends the reply, causing duplicate texts alongside the crash loop.

Move the call into the branch where the conversation is known. The notification inline-reply path always supplies a conversation id, so its behavior is unchanged, and the recipients-only path has no active conversation notification to update in the first place.