### PR TITLE
Fix blocked conversation playing notification

### DIFF
--- a/app/src/test/kotlin/com/android/messaging/datamodel/BugleNotificationsBlockedConversationTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/datamodel/BugleNotificationsBlockedConversationTest.kt
@@ -1,0 +1,172 @@
+package com.android.messaging.datamodel
+
+import android.media.AudioManager
+import android.net.Uri
+import com.android.messaging.FactoryTestAccess
+import com.android.messaging.datamodel.data.ConversationListItemData
+import com.android.messaging.testutil.installTestFactory
+import com.android.messaging.util.RingtoneUtil
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class BugleNotificationsBlockedConversationTest {
+
+    private val database = mockk<DatabaseWrapper>(relaxed = true)
+    private val dataModel = mockk<DataModel>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        installTestFactory(
+            context = RuntimeEnvironment.getApplication().applicationContext,
+            dataModel = dataModel,
+        )
+        every { dataModel.getDatabase() } returns database
+        silenceRinger()
+        stubConversationLookup()
+        stubNotificationDelivery()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        FactoryTestAccess.reset()
+    }
+
+    @Test
+    fun createMessageNotification_withBlockedConversation_postsNoUnrelatedNotification() {
+        givenUnseenMessage(ALLOWED_CONVERSATION_ID)
+
+        BugleNotifications.createMessageNotification(BLOCKED_CONVERSATION_ID)
+
+        verify(exactly = 0) { BugleNotifications.processAndSend(any(), any()) }
+    }
+
+    @Test
+    fun createMessageNotification_withAllowedConversation_postsNotification() {
+        val conversation = givenUnseenMessage(ALLOWED_CONVERSATION_ID)
+
+        BugleNotifications.createMessageNotification(ALLOWED_CONVERSATION_ID)
+
+        verify(exactly = 1) { BugleNotifications.processAndSend(any(), conversation) }
+    }
+
+    @Test
+    fun createMessageNotification_withoutConversationId_skipsBlockedConversationInState() {
+        val blocked = createNotificationConversation(BLOCKED_CONVERSATION_ID)
+        val allowed = createNotificationConversation(ALLOWED_CONVERSATION_ID)
+        givenUnseenMessages(blocked, allowed)
+
+        BugleNotifications.createMessageNotification(null)
+
+        verify(exactly = 1) { BugleNotifications.processAndSend(any(), allowed) }
+    }
+
+    @Test
+    fun createMessageNotification_withBlockedObservableConversation_playsNoSound() {
+        givenNoUnseenMessages()
+        givenConversationObservable(BLOCKED_CONVERSATION_ID)
+
+        BugleNotifications.createMessageNotification(BLOCKED_CONVERSATION_ID)
+
+        verify(exactly = 0) { RingtoneUtil.getNotificationRingtoneUri(any(), any()) }
+    }
+
+    @Test
+    fun createMessageNotification_withAllowedObservableConversation_playsSound() {
+        givenNoUnseenMessages()
+        givenConversationObservable(ALLOWED_CONVERSATION_ID)
+
+        BugleNotifications.createMessageNotification(ALLOWED_CONVERSATION_ID)
+
+        verify(exactly = 1) {
+            RingtoneUtil.getNotificationRingtoneUri(ALLOWED_CONVERSATION_ID, null)
+        }
+    }
+
+    private fun stubConversationLookup() {
+        mockkStatic(ConversationListItemData::class)
+        stubConversation(BLOCKED_CONVERSATION_ID, BLOCKED_SENDER)
+        stubConversation(ALLOWED_CONVERSATION_ID, ALLOWED_SENDER)
+        mockkStatic(BugleDatabaseOperations::class)
+        every {
+            BugleDatabaseOperations.isBlockedDestination(database, BLOCKED_SENDER)
+        } returns true
+        every {
+            BugleDatabaseOperations.isBlockedDestination(database, ALLOWED_SENDER)
+        } returns false
+    }
+
+    private fun stubConversation(
+        conversationId: String,
+        sender: String,
+    ) {
+        val convData = mockk<ConversationListItemData>(relaxed = true)
+        every { convData.otherParticipantNormalizedDestination } returns sender
+        every { convData.notificationSoundUri } returns null
+        every {
+            ConversationListItemData.getExistingConversation(database, conversationId)
+        } returns convData
+    }
+
+    private fun stubNotificationDelivery() {
+        mockkStatic(MessageNotificationState::class)
+        mockkStatic(RingtoneUtil::class)
+        every { RingtoneUtil.getNotificationRingtoneUri(any(), any()) } returns RINGTONE_URI
+        mockkStatic(BugleNotifications::class)
+        every { BugleNotifications.processAndSend(any(), any()) } just runs
+    }
+
+    private fun silenceRinger() {
+        RuntimeEnvironment.getApplication()
+            .getSystemService(AudioManager::class.java)
+            .ringerMode = AudioManager.RINGER_MODE_SILENT
+    }
+
+    private fun givenUnseenMessage(
+        conversationId: String,
+    ): MessageNotificationState.Conversation {
+        return createNotificationConversation(conversationId).also { conversation ->
+            givenUnseenMessages(conversation)
+        }
+    }
+
+    private fun givenUnseenMessages(
+        vararg conversations: MessageNotificationState.Conversation,
+    ) {
+        val conversationsList = MessageNotificationState.ConversationsList(
+            conversations.size,
+            conversations.toList(),
+        )
+        every {
+            MessageNotificationState.getNotificationState()
+        } returns MessageNotificationState(conversationsList)
+    }
+
+    private fun givenNoUnseenMessages() {
+        every { MessageNotificationState.getNotificationState() } returns null
+    }
+
+    private fun givenConversationObservable(conversationId: String) {
+        every { dataModel.isNewMessageObservable(conversationId) } returns true
+    }
+
+    private companion object {
+        private const val BLOCKED_CONVERSATION_ID = "193"
+        private const val BLOCKED_SENDER = "+15551234567"
+        private const val ALLOWED_CONVERSATION_ID = "194"
+        private const val ALLOWED_SENDER = "+15557654321"
+        private val RINGTONE_URI: Uri = Uri.parse("content://settings/system/notification_sound")
+    }
+}

--- a/app/src/test/kotlin/com/android/messaging/datamodel/NotificationConversationFixtures.kt
+++ b/app/src/test/kotlin/com/android/messaging/datamodel/NotificationConversationFixtures.kt
@@ -1,0 +1,27 @@
+package com.android.messaging.datamodel
+
+import com.android.messaging.datamodel.data.ParticipantData
+
+internal fun createNotificationConversation(
+    conversationId: String,
+    conversationName: String = "Conversation",
+    selfParticipantId: String = "self-1",
+    receivedTimestamp: Long = 0L,
+    isGroup: Boolean = false,
+    participantCount: Int = 2,
+): MessageNotificationState.Conversation {
+    return MessageNotificationState.Conversation(
+        conversationId,
+        isGroup,
+        conversationName,
+        false,
+        receivedTimestamp,
+        selfParticipantId,
+        null,
+        true,
+        false,
+        ParticipantData.DEFAULT_SELF_SUB_ID,
+        participantCount,
+        null,
+    )
+}

--- a/src/com/android/messaging/datamodel/BugleNotifications.java
+++ b/src/com/android/messaging/datamodel/BugleNotifications.java
@@ -154,7 +154,13 @@ public class BugleNotifications {
         }
     }
 
-    private static void createMessageNotification(final String conversationId) {
+    @VisibleForTesting
+    static void createMessageNotification(final String conversationId) {
+        if (!TextUtils.isEmpty(conversationId) && isConversationBlocked(conversationId)) {
+            LogUtil.d(TAG, "Skipping notification: conversation blocked, id=" + conversationId);
+            return;
+        }
+
         final MessageNotificationState state = MessageNotificationState.getNotificationState();
         final boolean softSound = DataModel.get().isNewMessageObservable(conversationId);
         if (state == null) {
@@ -166,8 +172,9 @@ public class BugleNotifications {
         }
 
         // Send per-conversation notifications (if there are multiple conversations).
-        Optional<Conversation> conversation =
-                state.mConversationsList.mConversations.stream().findFirst();
+        Optional<Conversation> conversation = state.mConversationsList.mConversations.stream()
+                .filter(conv -> !isConversationBlocked(conv.mConversationId))
+                .findFirst();
         conversation.ifPresent(conv -> processAndSend(state, conv));
     }
 
@@ -223,6 +230,20 @@ public class BugleNotifications {
                 ConversationListItemData.getExistingConversation(db, conversationId);
         return RingtoneUtil.getNotificationRingtoneUri(conversationId,
                 convData != null ? convData.getNotificationSoundUri() : null);
+    }
+
+    private static boolean isConversationBlocked(final String conversationId) {
+        final DatabaseWrapper db = DataModel.get().getDatabase();
+        final ConversationListItemData convData =
+                ConversationListItemData.getExistingConversation(db, conversationId);
+
+        if (convData == null) {
+            return false;
+        }
+
+        final String otherDestination = convData.getOtherParticipantNormalizedDestination();
+        return otherDestination != null
+                && BugleDatabaseOperations.isBlockedDestination(db, otherDestination);
     }
 
     /**
@@ -322,7 +343,8 @@ public class BugleNotifications {
         }
     }
 
-    private static void processAndSend(final MessageNotificationState state, final Conversation conversation) {
+    @VisibleForTesting
+    static void processAndSend(final MessageNotificationState state, final Conversation conversation) {
         final Context context = Factory.get().getApplicationContext();
         final String conversationId = conversation.mConversationId;
         final NotificationCompat.Builder notifBuilder =


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/Messaging/issues/82

This only reproduces while the blocked conversation itself is open on screen. On the list or in the background the observable soft-sound path no longer fires.