### PR TITLE
Direct secondary users to the Owner user for MMS

### DIFF
--- a/app/src/sharedTest/kotlin/com/android/messaging/ui/conversation/messages/ui/message/rendering/BaseConversationMessageRenderingTest.kt
+++ b/app/src/sharedTest/kotlin/com/android/messaging/ui/conversation/messages/ui/message/rendering/BaseConversationMessageRenderingTest.kt
@@ -162,11 +162,13 @@ internal abstract class BaseConversationMessageRenderingTest {
         state: MmsDownloadUiModel.State = MmsDownloadUiModel.State.AwaitingManualDownload,
         sizeBytes: Long = MMS_SIZE_BYTES,
         expiryTimestamp: Long = MMS_EXPIRY_TIMESTAMP,
+        isSecondaryUser: Boolean = false,
     ): MmsDownloadUiModel {
         return MmsDownloadUiModel(
             state = state,
             sizeBytes = sizeBytes,
             expiryTimestamp = expiryTimestamp,
+            isSecondaryUser = isSecondaryUser,
         )
     }
 

--- a/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/mapper/conversationmessage/BaseConversationMessageUiModelMapperTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/mapper/conversationmessage/BaseConversationMessageUiModelMapperTest.kt
@@ -8,10 +8,26 @@ import com.android.messaging.datamodel.data.MessagePartData
 import com.android.messaging.ui.conversation.attachment.mapper.ConversationVCardAttachmentUiModelMapper
 import com.android.messaging.ui.conversation.attachment.model.ConversationVCardAttachmentUiModel
 import com.android.messaging.ui.conversation.messages.mapper.ConversationMessageUiModelMapperImpl
+import com.android.messaging.util.OsUtil
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Before
 
 internal abstract class BaseConversationMessageUiModelMapperTest {
+
+    @Before
+    fun mockOsUtil() {
+        mockkStatic(OsUtil::class)
+        every { OsUtil.isSecondaryUser() } returns false
+    }
+
+    @After
+    fun unmockOsUtil() {
+        unmockkStatic(OsUtil::class)
+    }
 
     protected val vCardUiModel = ConversationVCardAttachmentUiModel(
         type = ConversationVCardAttachmentType.CONTACT,

--- a/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/mapper/conversationmessage/ConversationMessageUiModelMapperMmsDownloadTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/mapper/conversationmessage/ConversationMessageUiModelMapperMmsDownloadTest.kt
@@ -2,6 +2,8 @@ package com.android.messaging.ui.conversation.messages.mapper.conversationmessag
 
 import com.android.messaging.datamodel.data.MessageData
 import com.android.messaging.ui.conversation.messages.model.message.MmsDownloadUiModel
+import com.android.messaging.util.OsUtil
+import io.mockk.every
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -28,6 +30,29 @@ internal class ConversationMessageUiModelMapperMmsDownloadTest :
                 sizeBytes = 2_048L,
                 expiryTimestamp = 1_700_000_000_000L,
                 isSecondaryUser = false,
+            ),
+            uiModel.mmsDownload,
+        )
+    }
+
+    @Test
+    fun map_awaitingManualDownloadStatusAsSecondaryUser_buildsSecondaryUserMmsDownload() {
+        every { OsUtil.isSecondaryUser() } returns true
+
+        val uiModel = mapper.map(
+            messageData(
+                status = MessageData.BUGLE_STATUS_INCOMING_YET_TO_MANUAL_DOWNLOAD,
+                smsMessageSize = 2_048,
+                mmsExpiry = 1_700_000_000_000L,
+            ),
+        )
+
+        assertEquals(
+            MmsDownloadUiModel(
+                state = MmsDownloadUiModel.State.AwaitingManualDownload,
+                sizeBytes = 2_048L,
+                expiryTimestamp = 1_700_000_000_000L,
+                isSecondaryUser = true,
             ),
             uiModel.mmsDownload,
         )

--- a/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/mapper/conversationmessage/ConversationMessageUiModelMapperMmsDownloadTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/mapper/conversationmessage/ConversationMessageUiModelMapperMmsDownloadTest.kt
@@ -27,6 +27,7 @@ internal class ConversationMessageUiModelMapperMmsDownloadTest :
                 state = MmsDownloadUiModel.State.AwaitingManualDownload,
                 sizeBytes = 2_048L,
                 expiryTimestamp = 1_700_000_000_000L,
+                isSecondaryUser = false,
             ),
             uiModel.mmsDownload,
         )

--- a/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/ui/message/ResolveConversationMessageSimDisplayNameTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/ui/message/ResolveConversationMessageSimDisplayNameTest.kt
@@ -152,6 +152,7 @@ class ResolveConversationMessageSimDisplayNameTest {
             state = MmsDownloadUiModel.State.AwaitingManualDownload,
             sizeBytes = 0L,
             expiryTimestamp = 0L,
+            isSecondaryUser = false,
         )
     }
 

--- a/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/ui/message/rendering/ConversationMmsDownloadBodyRenderingTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/conversation/messages/ui/message/rendering/ConversationMmsDownloadBodyRenderingTest.kt
@@ -83,6 +83,86 @@ internal class ConversationMmsDownloadBodyRenderingTest :
     }
 
     @Test
+    fun secondaryUserAwaitingManualDownload_rendersOwnerUserReferral() {
+        setMmsDownloadBodyContent(
+            download = mmsDownload(
+                state = MmsDownloadUiModel.State.AwaitingManualDownload,
+                isSecondaryUser = true,
+            ),
+            canDownloadMessage = true,
+        )
+
+        composeTestRule
+            .onNodeWithText(
+                text = stringResourceText(R.string.message_title_download_secondary_user)
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                text = stringResourceText(R.string.message_status_download_secondary_user)
+            )
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun secondaryUserDownloadFailed_rendersOwnerUserReferral() {
+        setMmsDownloadBodyContent(
+            download = mmsDownload(
+                state = MmsDownloadUiModel.State.DownloadFailed,
+                isSecondaryUser = true,
+            ),
+            canDownloadMessage = true,
+        )
+
+        composeTestRule
+            .onNodeWithText(
+                text = stringResourceText(R.string.message_title_download_secondary_user)
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                text = stringResourceText(R.string.message_status_download_secondary_user),
+            )
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun secondaryUserDownloading_rendersRegularDownloadingStatus() {
+        setMmsDownloadBodyContent(
+            download = mmsDownload(
+                state = MmsDownloadUiModel.State.Downloading,
+                isSecondaryUser = true,
+            ),
+            canDownloadMessage = false,
+        )
+
+        composeTestRule
+            .onNodeWithText(text = stringResourceText(R.string.message_title_downloading))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(text = stringResourceText(R.string.message_status_downloading))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun secondaryUserExpiredOrUnavailable_rendersUnavailableStatus() {
+        setMmsDownloadBodyContent(
+            download = mmsDownload(
+                state = MmsDownloadUiModel.State.ExpiredOrUnavailable,
+                isSecondaryUser = true,
+            ),
+            canDownloadMessage = false,
+        )
+
+        composeTestRule
+            .onNodeWithText(text = stringResourceText(R.string.message_title_download_failed))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(text = stringResourceText(R.string.message_status_download_error))
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun simDisplayName_presentAppendsSimAnnotation() {
         val statusLine = buildStatusLineText(
             statusText = stringResourceText(R.string.message_status_download),

--- a/app/src/test/kotlin/com/android/messaging/ui/conversationlist/chats/mapper/ConversationListUiStateMapperImplTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/conversationlist/chats/mapper/ConversationListUiStateMapperImplTest.kt
@@ -1,6 +1,7 @@
 package com.android.messaging.ui.conversationlist.chats.mapper
 
 import android.content.Context
+import com.android.messaging.R
 import com.android.messaging.data.conversationlist.model.ConversationListMessageStatus
 import com.android.messaging.data.conversationlist.model.ConversationListSnapshot
 import com.android.messaging.domain.conversation.usecase.avatar.ResolveAvatarUri
@@ -15,14 +16,19 @@ import com.android.messaging.ui.conversationlist.mapper.ConversationListItemUiMa
 import com.android.messaging.ui.conversationlist.model.ConversationListContentUiState
 import com.android.messaging.ui.conversationlist.model.ConversationListItemUiModel
 import com.android.messaging.ui.conversationlist.snapshotOf
+import com.android.messaging.util.OsUtil
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 internal class ConversationListUiStateMapperImplTest {
@@ -49,6 +55,17 @@ internal class ConversationListUiStateMapperImplTest {
         canAddContact = canAddContact,
         contentMapper = contentMapper,
     )
+
+    @Before
+    fun setUp() {
+        mockkStatic(OsUtil::class)
+        every { OsUtil.isSecondaryUser() } returns false
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(OsUtil::class)
+    }
 
     @Test
     fun map_pinnedConversation_marksItemPinned() {
@@ -219,7 +236,29 @@ internal class ConversationListUiStateMapperImplTest {
 
         val item = singleItem(state)
         assertEquals(ConversationListMessageStatus.IncomingAwaitingManualDownload, item.status)
+        assertEquals(R.string.message_title_manual_download, item.mmsDownloadTitleResId)
         assertFalse(item.isOutgoing)
+    }
+
+    @Test
+    fun map_incomingMmsDownloadStatusAsSecondaryUser_referralsToOwnerUser() {
+        every { OsUtil.isSecondaryUser() } returns true
+
+        val state = mapper.map(
+            snapshot = snapshotOf(
+                conversationItem(
+                    conversationId = "mms",
+                    status = ConversationListMessageStatus.IncomingAwaitingManualDownload,
+                ),
+            ),
+            selectedConversationIds = persistentListOf(),
+            isScrollToTopVisible = false,
+            isDebugEnabled = false,
+        )
+
+        val item = singleItem(state)
+        assertEquals(ConversationListMessageStatus.IncomingAwaitingManualDownload, item.status)
+        assertEquals(R.string.message_title_download_secondary_user, item.mmsDownloadTitleResId)
     }
 
     @Test

--- a/app/src/test/kotlin/com/android/messaging/ui/conversationlist/mapper/ConversationListContentUiStateMapperImplTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/conversationlist/mapper/ConversationListContentUiStateMapperImplTest.kt
@@ -9,14 +9,31 @@ import com.android.messaging.domain.conversation.usecase.telephony.CanPlacePhone
 import com.android.messaging.ui.conversationlist.conversationItem
 import com.android.messaging.ui.conversationlist.model.ConversationListContentUiState
 import com.android.messaging.ui.conversationlist.snapshotOf
+import com.android.messaging.util.OsUtil
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 internal class ConversationListContentUiStateMapperImplTest {
+
+    @Before
+    fun setUp() {
+        mockkStatic(OsUtil::class)
+        every { OsUtil.isSecondaryUser() } returns false
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(OsUtil::class)
+    }
 
     private val itemUiMapper = ConversationListItemUiMapperImpl(
         context = mockk<Context>(relaxed = true),

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -200,6 +200,10 @@
     <string name="message_status_downloading">Downloading&#8230;</string>
     <!-- Timestamp line for MMS for expired or invalid message. -->
     <string name="message_status_download_error">Message expired or not available</string>
+    <!-- Title line for an MMS that only the Owner user can download. -->
+    <string name="message_title_download_secondary_user">MMS not available for this user</string>
+    <!-- Timestamp line for an MMS that only the Owner user can download. -->
+    <string name="message_status_download_secondary_user">Download it from the Owner user</string>
     <!-- Display this info line with an MMS notification -->
     <string name="mms_info">size: <xliff:g id="messageSize">%1$s</xliff:g>, expiration: <xliff:g id="messageExpire">%2$s</xliff:g></string>
     <!-- While sending a message, if it has invalid recipient, display this message. -->
@@ -497,6 +501,8 @@
     <!-- Title for the preference for whether or not to auto-retrieve MMS when roaming -->
     <string name="auto_retrieve_mms_when_roaming_pref_title">Roaming auto-retrieve</string>
     <string name="auto_retrieve_mms_when_roaming_pref_summary">Automatically retrieve MMS when roaming</string>
+    <!-- Auto-retrieve MMS summary shown to secondary users, who can't download MMS. -->
+    <string name="auto_retrieve_mms_secondary_user_summary">Only the Owner user can download MMS</string>
     <string name="group_mms_pref_title">Group messaging</string>
     <string name="group_mms_pref_summary">Use MMS to send a single message when there are multiple recipients</string>
     <!-- Preference title: SMS disabled (Messaging is not default SMS app) -->

--- a/src/com/android/messaging/data/conversationlist/model/ConversationListMessageStatus.kt
+++ b/src/com/android/messaging/data/conversationlist/model/ConversationListMessageStatus.kt
@@ -3,19 +3,19 @@ package com.android.messaging.data.conversationlist.model
 internal sealed interface ConversationListMessageStatus {
 
     sealed interface Error : ConversationListMessageStatus
+    sealed interface MmsDownload : ConversationListMessageStatus
 
     data object Unknown : ConversationListMessageStatus
     data object Normal : ConversationListMessageStatus
     data object Sending : ConversationListMessageStatus
     data object Draft : ConversationListMessageStatus
 
-    data object IncomingAwaitingManualDownload : ConversationListMessageStatus
-    data object IncomingDownloading : ConversationListMessageStatus
+    data object IncomingAwaitingManualDownload : MmsDownload
+    data object IncomingDownloading : MmsDownload
+    data object IncomingDownloadFailed : MmsDownload, Error
+    data object IncomingExpiredOrUnavailable : MmsDownload, Error
 
     data class Failed(
         val rawTelephonyStatus: Int,
     ) : Error
-
-    data object IncomingDownloadFailed : Error
-    data object IncomingExpiredOrUnavailable : Error
 }

--- a/src/com/android/messaging/datamodel/BugleNotifications.java
+++ b/src/com/android/messaging/datamodel/BugleNotifications.java
@@ -58,6 +58,7 @@ import com.android.messaging.util.AvatarUriUtil;
 import com.android.messaging.util.LogUtil;
 import com.android.messaging.util.NotificationChannelUtil;
 import com.android.messaging.util.NotificationPlayer;
+import com.android.messaging.util.OsUtil;
 import com.android.messaging.util.PendingIntentConstants;
 import com.android.messaging.util.PhoneUtils;
 import com.android.messaging.util.RingtoneUtil;
@@ -464,7 +465,8 @@ public class BugleNotifications {
         notifBuilder.addAction(replyActionBuilder.build());
 
         final String messageId = conversation.getLatestMessageId();
-        if (conversation.getDoesLatestMessageNeedDownload() && messageId != null) {
+        if (conversation.getDoesLatestMessageNeedDownload() && messageId != null
+                && !OsUtil.isSecondaryUser()) {
             final PendingIntent downloadPendingIntent =
                     RedownloadMmsAction.getPendingIntentForRedownloadMms(context, messageId);
 

--- a/src/com/android/messaging/datamodel/MessageNotificationState.java
+++ b/src/com/android/messaging/datamodel/MessageNotificationState.java
@@ -53,6 +53,7 @@ import com.android.messaging.util.ContentType;
 import com.android.messaging.util.ConversationIdSet;
 import com.android.messaging.util.LogUtil;
 import com.android.messaging.util.NotificationChannelUtil;
+import com.android.messaging.util.OsUtil;
 import com.android.messaging.util.PendingIntentConstants;
 import com.android.messaging.util.UriUtil;
 
@@ -456,8 +457,10 @@ public class MessageNotificationState {
                         // notification.
                         Assert.equals(MessageData.BUGLE_STATUS_INCOMING_YET_TO_MANUAL_DOWNLOAD,
                                 convMessageData.getStatus());
-                        text = context.getResources().getString(
-                                R.string.message_title_manual_download);
+                        final int downloadTitleResId = OsUtil.isSecondaryUser()
+                                ? R.string.message_title_download_secondary_user
+                                : R.string.message_title_manual_download;
+                        text = context.getResources().getString(downloadTitleResId);
                     }
                     Conversation conversation = conversations.get(convId);
                     final Uri avatarUri = AvatarUriUtil.createAvatarUri(

--- a/src/com/android/messaging/datamodel/action/DownloadMmsAction.java
+++ b/src/com/android/messaging/datamodel/action/DownloadMmsAction.java
@@ -118,6 +118,14 @@ public class DownloadMmsAction extends Action implements Parcelable {
         final MessageData message = BugleDatabaseOperations.readMessage(db, messageId);
         if (message != null && message.canDownloadMessage()) {
             final Uri notificationUri = message.getSmsMessageUri();
+            if (notificationUri == null) {
+                LogUtil.w(TAG, "DownloadMmsAction: message " + messageId
+                        + " has no notification uri; skipping download");
+                updateMessageStatus(null, messageId, message.getConversationId(),
+                        MessageData.BUGLE_STATUS_INCOMING_DOWNLOAD_FAILED,
+                        MessageData.RAW_TELEPHONY_STATUS_UNDEFINED);
+                return true;
+            }
             final String conversationId = message.getConversationId();
             final int status = message.getStatus();
 

--- a/src/com/android/messaging/debug/TestDataSeeder.kt
+++ b/src/com/android/messaging/debug/TestDataSeeder.kt
@@ -957,7 +957,6 @@ private fun insertMmsDownloadMessage(
             put(MessageColumns.RECEIVED_TIMESTAMP, timestamp)
             put(MessageColumns.SEEN, 1)
             put(MessageColumns.READ, 1)
-            put(MessageColumns.SMS_MESSAGE_URI, "content://mms/${900_000 + seedIndex}")
             put(MessageColumns.SMS_PRIORITY, 0)
             put(MessageColumns.SMS_MESSAGE_SIZE, messageSizeBytes)
             put(MessageColumns.MMS_TRANSACTION_ID, "seeded-transaction-$seedIndex")

--- a/src/com/android/messaging/sms/MmsUtils.java
+++ b/src/com/android/messaging/sms/MmsUtils.java
@@ -1951,6 +1951,9 @@ public class MmsUtils {
     }
 
     public static void clearMmsStatus(final Context context, final Uri uri) {
+        if (uri == null) {
+            return;
+        }
         // Messaging application can leave invalid values in STATUS field of M-Notification.ind
         // messages.  Take this opportunity to clear it.
         // Downloading status just kept in local db and not reflected into telephony.

--- a/src/com/android/messaging/ui/appsettings/subscription/mapper/SubscriptionSettingsUiStateMapper.kt
+++ b/src/com/android/messaging/ui/appsettings/subscription/mapper/SubscriptionSettingsUiStateMapper.kt
@@ -6,6 +6,7 @@ import com.android.messaging.data.subscriptionsettings.model.PerSubscriptionData
 import com.android.messaging.data.subscriptionsettings.model.SubscriptionSettingsData
 import com.android.messaging.ui.appsettings.subscription.model.SubscriptionSettingsUiState
 import com.android.messaging.ui.appsettings.subscription.model.SubscriptionUiState
+import com.android.messaging.util.OsUtil
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.collections.immutable.ImmutableList
@@ -121,6 +122,7 @@ internal class SubscriptionSettingsUiStateMapperImpl @Inject constructor(
             deliveryReportsEnabled = perSub.deliveryReportsEnabled,
             isWirelessAlertsSupported = perSub.showCellBroadcast && isCellBroadcastAppEnabled,
             isDefaultSmsApp = isDefaultSmsApp,
+            isSecondaryUser = OsUtil.isSecondaryUser(),
         )
     }
 }

--- a/src/com/android/messaging/ui/appsettings/subscription/model/SubscriptionUiState.kt
+++ b/src/com/android/messaging/ui/appsettings/subscription/model/SubscriptionUiState.kt
@@ -17,4 +17,5 @@ internal data class SubscriptionUiState(
     val deliveryReportsEnabled: Boolean = false,
     val isWirelessAlertsSupported: Boolean = false,
     val isDefaultSmsApp: Boolean = false,
+    val isSecondaryUser: Boolean = false,
 )

--- a/src/com/android/messaging/ui/appsettings/subscription/ui/SubscriptionSettingsScreen.kt
+++ b/src/com/android/messaging/ui/appsettings/subscription/ui/SubscriptionSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.android.messaging.ui.appsettings.subscription.ui
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -169,31 +170,65 @@ private fun LazyListScope.mmsSettingsItems(
         )
     }
 
-    item(key = "auto_retrieve_mms") {
-        SettingsSwitchItem(
-            title = stringResource(R.string.auto_retrieve_mms_pref_title),
-            summary = stringResource(R.string.auto_retrieve_mms_pref_summary),
-            checked = subscriptionSettings.autoRetrieveMms,
-            enabled = subscriptionSettings.isDefaultSmsApp,
-            onCheckedChange = { enabled ->
-                onAction(
-                    Action.AutoRetrieveMmsChanged(subscriptionSettings.subId, enabled),
-                )
-            },
-        )
-    }
+    autoRetrieveMmsItems(
+        subscriptionSettings = subscriptionSettings,
+        onAction = onAction,
+    )
+}
 
-    item(key = "auto_retrieve_mms_roaming") {
+private fun LazyListScope.autoRetrieveMmsItems(
+    subscriptionSettings: SubscriptionUiState,
+    onAction: (Action) -> Unit,
+) {
+    autoRetrieveSwitchItem(
+        key = "auto_retrieve_mms",
+        subscriptionSettings = subscriptionSettings,
+        titleResId = R.string.auto_retrieve_mms_pref_title,
+        summaryResId = R.string.auto_retrieve_mms_pref_summary,
+        checked = subscriptionSettings.autoRetrieveMms,
+        dependencyEnabled = true,
+        onCheckedChange = { enabled ->
+            onAction(Action.AutoRetrieveMmsChanged(subscriptionSettings.subId, enabled))
+        },
+    )
+
+    autoRetrieveSwitchItem(
+        key = "auto_retrieve_mms_roaming",
+        subscriptionSettings = subscriptionSettings,
+        titleResId = R.string.auto_retrieve_mms_when_roaming_pref_title,
+        summaryResId = R.string.auto_retrieve_mms_when_roaming_pref_summary,
+        checked = subscriptionSettings.autoRetrieveMmsWhenRoaming,
+        dependencyEnabled = subscriptionSettings.autoRetrieveMms,
+        onCheckedChange = { enabled ->
+            onAction(Action.AutoRetrieveMmsWhenRoamingChanged(subscriptionSettings.subId, enabled))
+        },
+    )
+}
+
+private fun LazyListScope.autoRetrieveSwitchItem(
+    key: String,
+    subscriptionSettings: SubscriptionUiState,
+    @StringRes titleResId: Int,
+    @StringRes summaryResId: Int,
+    checked: Boolean,
+    dependencyEnabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    item(key = key) {
         SettingsSwitchItem(
-            title = stringResource(R.string.auto_retrieve_mms_when_roaming_pref_title),
-            summary = stringResource(R.string.auto_retrieve_mms_when_roaming_pref_summary),
-            checked = subscriptionSettings.autoRetrieveMmsWhenRoaming,
-            enabled = subscriptionSettings.isDefaultSmsApp && subscriptionSettings.autoRetrieveMms,
-            onCheckedChange = { enabled ->
-                onAction(
-                    Action.AutoRetrieveMmsWhenRoamingChanged(subscriptionSettings.subId, enabled),
-                )
+            title = stringResource(titleResId),
+            summary = when {
+                subscriptionSettings.isSecondaryUser -> {
+                    stringResource(R.string.auto_retrieve_mms_secondary_user_summary)
+                }
+
+                else -> stringResource(summaryResId)
             },
+            checked = checked,
+            enabled = subscriptionSettings.isDefaultSmsApp &&
+                dependencyEnabled &&
+                !subscriptionSettings.isSecondaryUser,
+            onCheckedChange = onCheckedChange,
         )
     }
 }

--- a/src/com/android/messaging/ui/conversation/messages/mapper/ConversationMessageUiModelMapper.kt
+++ b/src/com/android/messaging/ui/conversation/messages/mapper/ConversationMessageUiModelMapper.kt
@@ -10,6 +10,7 @@ import com.android.messaging.ui.conversation.messages.model.message.Conversation
 import com.android.messaging.ui.conversation.messages.model.message.MmsDownloadUiModel
 import com.android.messaging.util.ContentType
 import com.android.messaging.util.LogUtil
+import com.android.messaging.util.OsUtil
 import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -93,6 +94,7 @@ internal class ConversationMessageUiModelMapperImpl @Inject constructor(
                 state = state,
                 sizeBytes = data.smsMessageSize.toLong(),
                 expiryTimestamp = data.mmsExpiry,
+                isSecondaryUser = OsUtil.isSecondaryUser(),
             )
         }
     }

--- a/src/com/android/messaging/ui/conversation/messages/model/message/MmsDownloadUiModel.kt
+++ b/src/com/android/messaging/ui/conversation/messages/model/message/MmsDownloadUiModel.kt
@@ -7,6 +7,7 @@ internal data class MmsDownloadUiModel(
     val state: State,
     val sizeBytes: Long,
     val expiryTimestamp: Long,
+    val isSecondaryUser: Boolean,
 ) {
     enum class State {
         AwaitingManualDownload,

--- a/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMmsDownloadBody.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/message/ConversationMmsDownloadBody.kt
@@ -37,12 +37,26 @@ internal fun ConversationMmsDownloadBody(
         isSelected = isSelected,
         contentColor = contentColor,
     )
+    val isSecondaryUserReferral = isSecondaryUserDownloadReferral(
+        state = download.state,
+        isSecondaryUser = download.isSecondaryUser,
+    )
 
     ConversationMmsDownloadBodyContent(
-        titleText = stringResource(id = mmsDownloadTitleResId(state = download.state)),
+        titleText = stringResource(
+            id = mmsDownloadTitleResId(
+                state = download.state,
+                isSecondaryUserReferral = isSecondaryUserReferral,
+            ),
+        ),
         infoText = rememberMmsDownloadInfoText(download = download),
         statusLineText = rememberMmsDownloadStatusLineText(
-            statusText = stringResource(id = mmsDownloadStatusResId(state = download.state)),
+            statusText = stringResource(
+                id = mmsDownloadStatusResId(
+                    state = download.state,
+                    isSecondaryUserReferral = isSecondaryUserReferral,
+                ),
+            ),
             simDisplayName = simDisplayName,
         ),
         contentColor = contentColor,
@@ -50,6 +64,7 @@ internal fun ConversationMmsDownloadBody(
         statusColor = mmsDownloadStatusColor(
             state = download.state,
             canDownloadMessage = canDownloadMessage,
+            isSecondaryUserReferral = isSecondaryUserReferral,
             isSelected = isSelected,
             contentColor = contentColor,
             supportingColor = supportingColor,
@@ -144,28 +159,37 @@ private fun rememberMmsDownloadStatusLineText(
 private fun mmsDownloadStatusColor(
     state: MmsDownloadUiModel.State,
     canDownloadMessage: Boolean,
+    isSecondaryUserReferral: Boolean,
     isSelected: Boolean,
     contentColor: Color,
     supportingColor: Color,
 ): Color {
+    val canRetryDownload = canDownloadMessage &&
+        (
+            state == MmsDownloadUiModel.State.AwaitingManualDownload ||
+                state == MmsDownloadUiModel.State.DownloadFailed
+            )
+    val isDownloadError = state == MmsDownloadUiModel.State.DownloadFailed ||
+        state == MmsDownloadUiModel.State.ExpiredOrUnavailable
+
     return when {
         isSelected -> contentColor
-        state == MmsDownloadUiModel.State.AwaitingManualDownload && canDownloadMessage -> {
-            MaterialTheme.colorScheme.primary
-        }
-        state == MmsDownloadUiModel.State.DownloadFailed && canDownloadMessage -> {
-            MaterialTheme.colorScheme.primary
-        }
-        state == MmsDownloadUiModel.State.DownloadFailed -> MaterialTheme.colorScheme.error
-        state == MmsDownloadUiModel.State.ExpiredOrUnavailable -> {
-            MaterialTheme.colorScheme.error
-        }
+        isSecondaryUserReferral -> supportingColor
+        canRetryDownload -> MaterialTheme.colorScheme.primary
+        isDownloadError -> MaterialTheme.colorScheme.error
         else -> supportingColor
     }
 }
 
 @StringRes
-private fun mmsDownloadTitleResId(state: MmsDownloadUiModel.State): Int {
+private fun mmsDownloadTitleResId(
+    state: MmsDownloadUiModel.State,
+    isSecondaryUserReferral: Boolean,
+): Int {
+    if (isSecondaryUserReferral) {
+        return R.string.message_title_download_secondary_user
+    }
+
     return when (state) {
         MmsDownloadUiModel.State.AwaitingManualDownload -> {
             R.string.message_title_manual_download
@@ -179,7 +203,14 @@ private fun mmsDownloadTitleResId(state: MmsDownloadUiModel.State): Int {
 }
 
 @StringRes
-private fun mmsDownloadStatusResId(state: MmsDownloadUiModel.State): Int {
+private fun mmsDownloadStatusResId(
+    state: MmsDownloadUiModel.State,
+    isSecondaryUserReferral: Boolean,
+): Int {
+    if (isSecondaryUserReferral) {
+        return R.string.message_status_download_secondary_user
+    }
+
     return when (state) {
         MmsDownloadUiModel.State.AwaitingManualDownload -> {
             R.string.message_status_download
@@ -189,6 +220,18 @@ private fun mmsDownloadStatusResId(state: MmsDownloadUiModel.State): Int {
         MmsDownloadUiModel.State.ExpiredOrUnavailable -> {
             R.string.message_status_download_error
         }
+    }
+}
+
+private fun isSecondaryUserDownloadReferral(
+    state: MmsDownloadUiModel.State,
+    isSecondaryUser: Boolean,
+): Boolean {
+    return isSecondaryUser && when (state) {
+        MmsDownloadUiModel.State.AwaitingManualDownload -> true
+        MmsDownloadUiModel.State.DownloadFailed -> true
+        MmsDownloadUiModel.State.Downloading -> false
+        MmsDownloadUiModel.State.ExpiredOrUnavailable -> false
     }
 }
 

--- a/src/com/android/messaging/ui/conversation/preview/ConversationPreviewData.kt
+++ b/src/com/android/messaging/ui/conversation/preview/ConversationPreviewData.kt
@@ -491,11 +491,13 @@ internal fun previewInlineVCardAttachment(
 
 internal fun previewMmsDownloadUiModel(
     state: MmsDownloadUiModel.State = MmsDownloadUiModel.State.AwaitingManualDownload,
+    isSecondaryUser: Boolean = false,
 ): MmsDownloadUiModel {
     return MmsDownloadUiModel(
         state = state,
         sizeBytes = 2_400_000L,
         expiryTimestamp = PREVIEW_NOW_MILLIS + 86_400_000L,
+        isSecondaryUser = isSecondaryUser,
     )
 }
 

--- a/src/com/android/messaging/ui/conversationlist/common/support/ConversationListPreviewSupport.kt
+++ b/src/com/android/messaging/ui/conversationlist/common/support/ConversationListPreviewSupport.kt
@@ -54,7 +54,10 @@ internal fun previewConversationListItem(
         subject = subject,
         timestampMillis = PREVIEW_TIMESTAMP_MILLIS,
         status = status,
-        mmsDownloadTitleResId = conversationListMmsDownloadTitleResId(status),
+        mmsDownloadTitleResId = conversationListMmsDownloadTitleResId(
+            status = status,
+            isSecondaryUser = false,
+        ),
         isOutgoing = isOutgoing,
         isUnread = isUnread,
         isEnterprise = isEnterprise,

--- a/src/com/android/messaging/ui/conversationlist/mapper/ConversationListItemUiMapper.kt
+++ b/src/com/android/messaging/ui/conversationlist/mapper/ConversationListItemUiMapper.kt
@@ -13,6 +13,7 @@ import com.android.messaging.ui.conversationlist.model.ConversationListItemUiMod
 import com.android.messaging.ui.conversationlist.model.ConversationListPreviewUiModel
 import com.android.messaging.ui.conversationlist.model.ConversationListSnippetUiModel
 import com.android.messaging.util.ContentType
+import com.android.messaging.util.OsUtil
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
@@ -55,7 +56,10 @@ internal class ConversationListItemUiMapperImpl @Inject constructor(
             subject = activeSubject(),
             timestampMillis = latestMessage.timestamp,
             status = status,
-            mmsDownloadTitleResId = conversationListMmsDownloadTitleResId(status),
+            mmsDownloadTitleResId = conversationListMmsDownloadTitleResId(
+                status = status,
+                isSecondaryUser = OsUtil.isSecondaryUser(),
+            ),
             isOutgoing = isOutgoing,
             isUnread = !latestMessage.isRead,
             isEnterprise = participant.isEnterprise,

--- a/src/com/android/messaging/ui/conversationlist/mapper/ConversationListMmsDownloadTitle.kt
+++ b/src/com/android/messaging/ui/conversationlist/mapper/ConversationListMmsDownloadTitle.kt
@@ -3,12 +3,27 @@ package com.android.messaging.ui.conversationlist.mapper
 import androidx.annotation.StringRes
 import com.android.messaging.R
 import com.android.messaging.data.conversationlist.model.ConversationListMessageStatus
+import com.android.messaging.data.conversationlist.model.ConversationListMessageStatus.MmsDownload
 
 @StringRes
 internal fun conversationListMmsDownloadTitleResId(
     status: ConversationListMessageStatus,
+    isSecondaryUser: Boolean,
 ): Int? {
-    return when (status) {
+    val downloadStatus = status as? MmsDownload ?: return null
+
+    return when {
+        isSecondaryUser && downloadStatus.isSecondaryUserDownloadReferral() -> {
+            R.string.message_title_download_secondary_user
+        }
+
+        else -> downloadStatus.regularTitleResId()
+    }
+}
+
+@StringRes
+private fun MmsDownload.regularTitleResId(): Int {
+    return when (this) {
         ConversationListMessageStatus.IncomingAwaitingManualDownload -> {
             R.string.message_title_manual_download
         }
@@ -22,7 +37,14 @@ internal fun conversationListMmsDownloadTitleResId(
         -> {
             R.string.message_title_download_failed
         }
+    }
+}
 
-        else -> null
+private fun MmsDownload.isSecondaryUserDownloadReferral(): Boolean {
+    return when (this) {
+        ConversationListMessageStatus.IncomingAwaitingManualDownload -> true
+        ConversationListMessageStatus.IncomingDownloadFailed -> true
+        ConversationListMessageStatus.IncomingDownloading -> false
+        ConversationListMessageStatus.IncomingExpiredOrUnavailable -> false
     }
 }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/Messaging/issues/170

Secondary users can't download MMS, so undownloaded messages now say "Download it from the Owner user" and the auto-retrieve switches are disabled with an explanation.

Seeder: dropped a fake `sms_message_uri`. Because it was set, sync treated the seeded rows as real telephony messages and deleted them, so they disappeared on device. `DownloadMmsAction`/`clearMmsStatus`: added a null-URI guard so a local-only row without a telephony URI doesn't try to download. Real messages always have a URI, so nothing changes for them.