### PR TITLE
Fix incoming SMS not imported until the app is opened

### DIFF
--- a/app/src/test/kotlin/com/android/messaging/data/sms/IncomingSmsDelivererImplTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/data/sms/IncomingSmsDelivererImplTest.kt
@@ -1,0 +1,88 @@
+package com.android.messaging.data.sms
+
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.telephony.SmsMessage
+import com.android.messaging.datamodel.DataModel
+import com.android.messaging.datamodel.action.ReceiveSmsMessageAction
+import com.android.messaging.sms.MmsUtils
+import com.android.messaging.util.DebugUtils
+import com.android.messaging.util.PhoneUtils
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class IncomingSmsDelivererImplTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val intent: Intent = mockk(relaxed = true)
+    private val parser: IncomingSmsParser = mockk()
+
+    // DCS 0 → message class UNKNOWN (not class 0), so it routes to ReceiveSmsMessageAction.
+    private val message: SmsMessage = SmsMessage.createFromPdu(SMS_DELIVER_PDU, SMS_FORMAT_3GPP)
+    private val deliverer = IncomingSmsDelivererImpl(parser)
+
+    @Before
+    fun setUp() {
+        mockkStatic(MmsUtils::class, DebugUtils::class, PhoneUtils::class, DataModel::class)
+        every { MmsUtils.parseReceivedSmsMessage(any(), any(), any()) } returns ContentValues()
+        every { MmsUtils.getMessageDate(any(), any()) } returns RECEIVED_AT
+        every { MmsUtils.isDumpSmsEnabled() } returns false
+        every { DebugUtils.debugClassZeroSmsEnabled() } returns false
+        every { DataModel.executeActionImmediately(any()) } just Runs
+        every { DataModel.startActionService(any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun deliverFromIntent_executesReceiveActionImmediately() {
+        every { parser.parse(intent) } returns arrayOf(message)
+        every { PhoneUtils.getDefault() } returns mockk {
+            every { getEffectiveIncomingSubIdFromSystem(any(), any()) } returns SUB_ID
+        }
+
+        deliverer.deliverFromIntent(context, intent)
+
+        verify { DataModel.executeActionImmediately(any<ReceiveSmsMessageAction>()) }
+        verify(exactly = 0) { DataModel.startActionService(any()) }
+    }
+
+    @Test
+    fun deliver_startsReceiveActionAsynchronously() {
+        deliverer.deliver(context, SUB_ID, NO_ERROR_CODE, arrayOf(message))
+
+        verify { DataModel.startActionService(any<ReceiveSmsMessageAction>()) }
+        verify(exactly = 0) { DataModel.executeActionImmediately(any()) }
+    }
+
+    private companion object {
+        private const val SUB_ID = 1
+        private const val NO_ERROR_CODE = -1
+        private const val RECEIVED_AT = 1_000L
+        private const val SMS_FORMAT_3GPP = "3gpp"
+
+        // A valid GSM SMS-DELIVER PDU ("hellohello").
+        private const val SMS_DELIVER_PDU_HEX =
+            "07911326040000F0040B911346610089F60000208062917314080CC8F71D14969741F977FD07"
+
+        private val SMS_DELIVER_PDU: ByteArray =
+            ByteArray(SMS_DELIVER_PDU_HEX.length / 2) { index ->
+                SMS_DELIVER_PDU_HEX.substring(index * 2, index * 2 + 2).toInt(16).toByte()
+            }
+    }
+}

--- a/src/com/android/messaging/data/sms/IncomingSmsDeliverer.kt
+++ b/src/com/android/messaging/data/sms/IncomingSmsDeliverer.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.provider.Telephony.Sms
 import android.telephony.SmsMessage
 import com.android.messaging.Factory
+import com.android.messaging.datamodel.DataModel
 import com.android.messaging.datamodel.action.ReceiveSmsMessageAction
 import com.android.messaging.sms.MmsUtils
 import com.android.messaging.util.DebugUtils
@@ -34,11 +35,12 @@ internal class IncomingSmsDelivererImpl @Inject constructor(
         val errorCode = intent.getIntExtra(EXTRA_ERROR_CODE, NO_ERROR_CODE)
         val subId = PhoneUtils.getDefault()
             .getEffectiveIncomingSubIdFromSystem(intent, EXTRA_SUB_ID)
-        deliver(
+        deliverInternal(
             context = context,
             subId = subId,
             errorCode = errorCode,
             messages = messages,
+            executeImmediately = true,
         )
 
         if (MmsUtils.isDumpSmsEnabled()) {
@@ -52,6 +54,22 @@ internal class IncomingSmsDelivererImpl @Inject constructor(
         subId: Int,
         errorCode: Int,
         messages: Array<SmsMessage>,
+    ) {
+        deliverInternal(
+            context = context,
+            subId = subId,
+            errorCode = errorCode,
+            messages = messages,
+            executeImmediately = false,
+        )
+    }
+
+    private fun deliverInternal(
+        context: Context,
+        subId: Int,
+        errorCode: Int,
+        messages: Array<SmsMessage>,
+        executeImmediately: Boolean,
     ) {
         val firstMessage = messages.first()
         val messageValues = MmsUtils.parseReceivedSmsMessage(context, messages, errorCode)
@@ -71,7 +89,13 @@ internal class IncomingSmsDelivererImpl @Inject constructor(
             isClassZero -> Factory.get().getUIIntents()
                 .launchClassZeroActivity(context, messageValues)
 
-            else -> ReceiveSmsMessageAction(messageValues).start()
+            else -> {
+                val action = ReceiveSmsMessageAction(messageValues)
+                when {
+                    executeImmediately -> DataModel.executeActionImmediately(action)
+                    else -> action.start()
+                }
+            }
         }
     }
 

--- a/src/com/android/messaging/datamodel/DataModel.java
+++ b/src/com/android/messaging/datamodel/DataModel.java
@@ -52,6 +52,11 @@ public abstract class DataModel {
         get().getActionService().startAction(action);
     }
 
+    @DoesNotRunOnMainThread
+    public static final void executeActionImmediately(final Action action) {
+        get().getActionService().executeActionImmediately(action);
+    }
+
     public static final void scheduleAction(final Action action,
             final int code, final long delayMs) {
         get().getActionService().scheduleAction(action, code, delayMs);

--- a/src/com/android/messaging/datamodel/action/ActionService.java
+++ b/src/com/android/messaging/datamodel/action/ActionService.java
@@ -38,6 +38,13 @@ public class ActionService {
     }
 
     /**
+     * Execute an action synchronously instead of posting it over the ActionService
+     */
+    public void executeActionImmediately(final Action action) {
+        ActionServiceImpl.executeActionImmediately(action);
+    }
+
+    /**
      * Schedule a delayed action by posting it over the the ActionService
      */
     public void scheduleAction(final Action action, final int code,

--- a/src/com/android/messaging/datamodel/action/ActionServiceImpl.java
+++ b/src/com/android/messaging/datamodel/action/ActionServiceImpl.java
@@ -78,6 +78,26 @@ public class ActionServiceImpl extends JobIntentService {
     }
 
     /**
+     * Execute action synchronously on the calling thread instead of queueing it on the service
+     * @param action - action to execute
+     */
+    public static void executeActionImmediately(final Action action) {
+        final LoggingTimer timer =
+                createLoggingTimer(action, "#executeActionImmediately");
+        final BackgroundWorker worker =
+                DataModel.get().getBackgroundWorkerForActionService();
+        action.markStart();
+        action.markBeginExecute();
+
+        timer.start();
+        final Object result = action.executeAction();
+        timer.stopAndLog();
+
+        action.markEndExecute(result);
+        action.sendBackgroundActions(worker);
+    }
+
+    /**
      * Handle response returned by BackgroundWorker
      * @param request - request generating response
      * @param response - response from service

--- a/src/com/android/messaging/receiver/SmsDeliverReceiver.kt
+++ b/src/com/android/messaging/receiver/SmsDeliverReceiver.kt
@@ -5,15 +5,27 @@ import android.content.Context
 import android.content.Intent
 import android.provider.Telephony.Sms
 import android.telephony.SmsMessage
-import com.android.messaging.data.sms.IncomingSmsDeliverer
 import com.android.messaging.di.receiver.IncomingSmsEntryPoint
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.launch
 
 class SmsDeliverReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == Sms.Intents.SMS_DELIVER_ACTION) {
-            delivererFrom(context).deliverFromIntent(context, intent)
+        if (intent.action != Sms.Intents.SMS_DELIVER_ACTION) {
+            return
+        }
+
+        // Import within the broadcast window, not via the job queue that JobScheduler can defer
+        val pendingResult = goAsync()
+        val appContext = context.applicationContext
+        val entryPoint = entryPoint(appContext)
+        entryPoint.applicationScope().launch(entryPoint.ioDispatcher()) {
+            try {
+                entryPoint.incomingSmsDeliverer().deliverFromIntent(appContext, intent)
+            } finally {
+                pendingResult.finish()
+            }
         }
     }
 
@@ -26,19 +38,19 @@ class SmsDeliverReceiver : BroadcastReceiver() {
             errorCode: Int,
             messages: Array<SmsMessage>,
         ) {
-            delivererFrom(context).deliver(
+            entryPoint(context).incomingSmsDeliverer().deliver(
                 context = context,
                 subId = subId,
                 errorCode = errorCode,
-                messages = messages
+                messages = messages,
             )
         }
 
-        private fun delivererFrom(context: Context): IncomingSmsDeliverer {
+        private fun entryPoint(context: Context): IncomingSmsEntryPoint {
             return EntryPointAccessors.fromApplication(
                 context.applicationContext,
                 IncomingSmsEntryPoint::class.java,
-            ).incomingSmsDeliverer()
+            )
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/Messaging/issues/155

Incoming SMS was posted to `ActionServiceImpl`, which `JobScheduler` defers while the app is backgrounded, so messages weren't imported and notifications stayed generic until the app was opened.
`SmsDeliverReceiver` now runs the receive action synchronously inside the `SMS_DELIVER` broadcast window.