### PR TITLE
Fix content sliding under the display cutout in landscape

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           cache: gradle
 
       - name: Run Detekt
-        run: ./gradlew :app:detekt --no-daemon --stacktrace --console=plain
+        run: ./gradlew :app:detektDebug --no-daemon --stacktrace --console=plain
 
       - name: Upload Detekt reports
         if: failure()

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -4,7 +4,10 @@ config:
 
 complexity:
   LongParameterList:
+    active: false
     ignoreDefaultParameters: true
+    ignoreAnnotated:
+      - Composable
   TooManyFunctions:
     allowedFunctionsPerClass: 60
     allowedFunctionsPerFile: 15
@@ -17,14 +20,33 @@ complexity:
       - Preview
       - PreviewLightDark
 
+coroutines:
+  InjectDispatcher:
+    active: false
+    ignoreAnnotated:
+      - Provides
+
 naming:
   FunctionNaming:
     ignoreAnnotated:
       - Composable
 
 style:
+  AbstractClassCanBeInterface:
+    ignoreAnnotated:
+      - Module
+
   ForbiddenComment:
     active: false
+
+  ForbiddenMethodCall:
+    active: true
+    methods:
+      - reason: >-
+          Does not cover the display cutout, so content slides under the camera
+          notch in landscape. Use bottomBarInsets(), imeAwareBottomBarInsets()
+          or safeDrawingContentPadding() from WindowInsetsExtensions instead.
+        value: 'androidx.compose.foundation.layout.navigationBarsPadding'
 
   MagicNumber:
     ignoreCompanionObjectPropertyDeclaration: true

--- a/src/com/android/messaging/data/contact/repository/ContactsRepository.kt
+++ b/src/com/android/messaging/data/contact/repository/ContactsRepository.kt
@@ -289,8 +289,7 @@ internal class ContactsRepositoryImpl @Inject constructor(
                     kind = kind,
                     destinationColumnName = destinationColumnName,
                 )
-            }
-            ?: emptyList()
+            }.orEmpty()
     }
 
     private fun mapDestinationRows(

--- a/src/com/android/messaging/data/conversation/repository/ConversationsRepository.kt
+++ b/src/com/android/messaging/data/conversation/repository/ConversationsRepository.kt
@@ -476,7 +476,6 @@ internal class ConversationsRepositoryImpl @Inject constructor(
                         add(ConversationMessageData().apply { bind(reversedCursor) })
                     }
                 }
-            }
-            ?: emptyList()
+            }.orEmpty()
     }
 }

--- a/src/com/android/messaging/data/media/repository/ConversationMediaRepository.kt
+++ b/src/com/android/messaging/data/media/repository/ConversationMediaRepository.kt
@@ -77,7 +77,7 @@ internal class ConversationMediaRepositoryImpl @Inject constructor(
                     add(item)
                 }
             }
-        } ?: emptyList()
+        }.orEmpty()
     }
 
     private fun createRecentMediaQueryArgs(limit: Int): Bundle {

--- a/src/com/android/messaging/data/media/repository/PhotoViewerRepository.kt
+++ b/src/com/android/messaging/data/media/repository/PhotoViewerRepository.kt
@@ -141,8 +141,7 @@ internal class PhotoViewerRepositoryImpl @Inject constructor(
                         }
                     }
                 }
-            }
-            ?: emptyList()
+            }.orEmpty()
     }
 
     private fun Cursor.toPhotoViewerItem(): PhotoViewerItem? {

--- a/src/com/android/messaging/domain/conversation/usecase/draft/SendConversationDraft.kt
+++ b/src/com/android/messaging/domain/conversation/usecase/draft/SendConversationDraft.kt
@@ -62,11 +62,9 @@ internal class SendConversationDraftImpl @Inject constructor(
                     draft = draft,
                     ignoreMessageSizeLimit = ignoreMessageSizeLimit,
                 )
+            } catch (exception: CancellationException) {
+                throw exception
             } catch (exception: Exception) {
-                if (exception is CancellationException) {
-                    throw exception
-                }
-
                 throw exception.toSendConversationDraftException(
                     conversationId = conversationId,
                 )

--- a/src/com/android/messaging/ui/blockedparticipants/screen/BlockedParticipantsScreen.kt
+++ b/src/com/android/messaging/ui/blockedparticipants/screen/BlockedParticipantsScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -31,7 +29,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -48,7 +45,7 @@ import com.android.messaging.ui.blockedparticipants.screen.model.BlockedParticip
 import com.android.messaging.ui.blockedparticipants.screen.model.BlockedParticipantsNavEvent as NavEvent
 import com.android.messaging.ui.blockedparticipants.screen.model.BlockedParticipantsUiState as State
 import com.android.messaging.ui.common.components.contentSurfaceShape
-import com.android.messaging.ui.common.components.horizontalSafeDrawingInsets
+import com.android.messaging.ui.common.components.safeDrawingContentPadding
 import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
@@ -151,16 +148,12 @@ private fun BlockedParticipantsList(
     onAction: (Action) -> Unit,
     scaffoldContentPadding: PaddingValues,
 ) {
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalInsets = horizontalSafeDrawingInsets()
-
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(
+        contentPadding = safeDrawingContentPadding(
             top = ScreenContentPadding,
             bottom = ScreenContentPadding + scaffoldContentPadding.calculateBottomPadding(),
-            start = ScreenContentPadding + horizontalInsets.calculateStartPadding(layoutDirection),
-            end = ScreenContentPadding + horizontalInsets.calculateEndPadding(layoutDirection),
+            horizontal = ScreenContentPadding,
         ),
     ) {
         itemsIndexed(

--- a/src/com/android/messaging/ui/common/components/WindowInsetsExtensions.kt
+++ b/src/com/android/messaging/ui/common/components/WindowInsetsExtensions.kt
@@ -4,13 +4,50 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
 
 @Composable
 fun horizontalSafeDrawingInsets(): PaddingValues {
     return WindowInsets.safeDrawing
         .only(WindowInsetsSides.Horizontal)
         .asPaddingValues()
+}
+
+@Composable
+fun safeDrawingContentPadding(
+    top: Dp,
+    bottom: Dp,
+    horizontal: Dp,
+): PaddingValues {
+    val layoutDirection = LocalLayoutDirection.current
+    val horizontalInsets = horizontalSafeDrawingInsets()
+
+    return PaddingValues(
+        top = top,
+        bottom = bottom,
+        start = horizontal + horizontalInsets.calculateStartPadding(layoutDirection),
+        end = horizontal + horizontalInsets.calculateEndPadding(layoutDirection),
+    )
+}
+
+@Composable
+fun bottomBarInsets(): WindowInsets {
+    return WindowInsets.systemBars
+        .union(WindowInsets.displayCutout)
+        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
+}
+
+@Composable
+fun imeAwareBottomBarInsets(): WindowInsets {
+    return WindowInsets.safeDrawing
+        .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
 }

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationComposeBar.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationComposeBar.kt
@@ -16,10 +16,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -49,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.domain.conversation.usecase.draft.model.ConversationDraftSendProtocol
 import com.android.messaging.ui.common.components.composer.MessageComposeBar
+import com.android.messaging.ui.common.components.imeAwareBottomBarInsets
 import com.android.messaging.ui.conversation.CONVERSATION_ATTACHMENT_BUTTON_TEST_TAG
 import com.android.messaging.ui.conversation.CONVERSATION_COMPOSE_BAR_TEST_TAG
 import com.android.messaging.ui.conversation.CONVERSATION_SEGMENT_COUNTER_TEST_TAG
@@ -127,8 +127,7 @@ internal fun ConversationComposeBar(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .imePadding()
-            .navigationBarsPadding()
+            .windowInsetsPadding(imeAwareBottomBarInsets())
             .testTag(CONVERSATION_COMPOSE_BAR_TEST_TAG),
     ) {
         ConversationComposeInputContent(

--- a/src/com/android/messaging/ui/conversation/composer/ui/ConversationSimSelectorSheet.kt
+++ b/src/com/android/messaging/ui/conversation/composer/ui/ConversationSimSelectorSheet.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
@@ -27,6 +27,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.data.subscription.model.Subscription
+import com.android.messaging.ui.common.components.bottomBarInsets
 import com.android.messaging.ui.conversation.CONVERSATION_SIM_SELECTOR_SHEET_TEST_TAG
 import com.android.messaging.ui.conversation.composer.model.ConversationSimSelectorUiState
 import com.android.messaging.ui.conversation.conversationSimSelectorItemTestTag
@@ -68,7 +69,7 @@ private fun ConversationSimSelectorSheetContent(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .navigationBarsPadding()
+            .windowInsetsPadding(bottomBarInsets())
             .padding(vertical = SHEET_VERTICAL_PADDING),
     ) {
         Text(

--- a/src/com/android/messaging/ui/conversation/messages/ui/ConversationMessages.kt
+++ b/src/com/android/messaging/ui/conversation/messages/ui/ConversationMessages.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.data.subscription.model.Subscription
+import com.android.messaging.ui.common.components.safeDrawingContentPadding
 import com.android.messaging.ui.conversation.CONVERSATION_MESSAGES_LIST_TEST_TAG
 import com.android.messaging.ui.conversation.conversationMessageItemTestTag
 import com.android.messaging.ui.conversation.messages.model.message.ConversationMessageUiModel
@@ -48,19 +49,8 @@ import kotlinx.collections.immutable.toImmutableMap
 
 private val MESSAGES_CONTENT_HORIZONTAL_PADDING = 16.dp
 private val MESSAGES_CONTENT_TOP_PADDING = 24.dp
-
-private val messagesContentPadding = PaddingValues(
-    start = MESSAGES_CONTENT_HORIZONTAL_PADDING,
-    top = MESSAGES_CONTENT_TOP_PADDING,
-    end = MESSAGES_CONTENT_HORIZONTAL_PADDING,
-    bottom = 24.dp,
-)
-private val sendSimContentPadding = PaddingValues(
-    start = MESSAGES_CONTENT_HORIZONTAL_PADDING,
-    top = MESSAGES_CONTENT_TOP_PADDING,
-    end = MESSAGES_CONTENT_HORIZONTAL_PADDING,
-    bottom = 6.dp,
-)
+private val MESSAGES_CONTENT_BOTTOM_PADDING = 24.dp
+private val SEND_SIM_CONTENT_BOTTOM_PADDING = 6.dp
 
 private val MESSAGES_CLUSTER_TOP_PADDING = 2.dp
 private val MESSAGES_GROUP_TOP_PADDING = 12.dp
@@ -219,24 +209,20 @@ private fun LazyListScope.conversationSendSimIndicatorItem(
     }
 }
 
+@Composable
 private fun conversationMessagesContentPadding(
     shouldShowSendSimIndicator: Boolean,
     additionalTopContentPadding: Dp,
 ): PaddingValues {
-    val basePadding = when {
-        shouldShowSendSimIndicator -> sendSimContentPadding
-        else -> messagesContentPadding
+    val bottomPadding = when {
+        shouldShowSendSimIndicator -> SEND_SIM_CONTENT_BOTTOM_PADDING
+        else -> MESSAGES_CONTENT_BOTTOM_PADDING
     }
 
-    if (additionalTopContentPadding <= 0.dp) {
-        return basePadding
-    }
-
-    return PaddingValues(
-        start = MESSAGES_CONTENT_HORIZONTAL_PADDING,
+    return safeDrawingContentPadding(
         top = MESSAGES_CONTENT_TOP_PADDING + additionalTopContentPadding,
-        end = MESSAGES_CONTENT_HORIZONTAL_PADDING,
-        bottom = basePadding.calculateBottomPadding(),
+        bottom = bottomPadding,
+        horizontal = MESSAGES_CONTENT_HORIZONTAL_PADDING,
     )
 }
 

--- a/src/com/android/messaging/ui/conversation/screen/ConversationBlockedBanner.kt
+++ b/src/com/android/messaging/ui/conversation/screen/ConversationBlockedBanner.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
+import com.android.messaging.ui.common.components.horizontalSafeDrawingInsets
 import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -75,7 +76,9 @@ internal fun ConversationBlockedBannerSlot(
     val density = LocalDensity.current
 
     AnimatedVisibility(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(paddingValues = horizontalSafeDrawingInsets()),
         visible = isRevealed,
         enter = fadeIn() + expandVertically(),
         exit = fadeOut() + shrinkVertically(),

--- a/src/com/android/messaging/ui/conversation/screen/ConversationScreenContent.kt
+++ b/src/com/android/messaging/ui/conversation/screen/ConversationScreenContent.kt
@@ -238,7 +238,10 @@ private fun Modifier.conversationScreenContentModifier(
     backdropColor: Color,
 ): Modifier {
     return this
-        .padding(paddingValues = contentPadding)
+        .padding(
+            top = contentPadding.calculateTopPadding(),
+            bottom = contentPadding.calculateBottomPadding(),
+        )
         .background(color = backdropColor)
         .clip(shape = MaterialTheme.contentSurfaceShape)
         .background(color = MaterialTheme.colorScheme.background)

--- a/src/com/android/messaging/ui/conversationlist/archived/ArchivedConversationListScreen.kt
+++ b/src/com/android/messaging/ui/conversationlist/archived/ArchivedConversationListScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
@@ -31,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.messaging.R
+import com.android.messaging.ui.common.components.contentSurfaceShape
 import com.android.messaging.ui.common.components.snackbar.MessagingSnackbarHost
 import com.android.messaging.ui.common.components.snackbar.showActionSnackbar
 import com.android.messaging.ui.conversationlist.archived.model.ArchivedConversationListAction as Action
@@ -50,11 +50,6 @@ import com.android.messaging.ui.core.MessagingPreviewTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-
-private val ContentCornerShape = RoundedCornerShape(
-    topStart = 28.dp,
-    topEnd = 28.dp,
-)
 
 private val ArchivedSwipeSpec = ConversationListSwipeSpec(
     startToEnd = ConversationSwipeKind.Unarchive,
@@ -200,7 +195,7 @@ private fun ArchivedConversationListScaffold(
                 .fillMaxSize()
                 .padding(top = contentPadding.calculateTopPadding())
                 .background(archivedBackdropColor(isSelectionMode))
-                .clip(ContentCornerShape)
+                .clip(MaterialTheme.contentSurfaceShape)
                 .background(MaterialTheme.colorScheme.background),
         ) {
             ArchivedConversationListContent(

--- a/src/com/android/messaging/ui/conversationpicker/ConversationPickerScreen.kt
+++ b/src/com/android/messaging/ui/conversationpicker/ConversationPickerScreen.kt
@@ -14,14 +14,9 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.text.input.TextFieldState
@@ -54,7 +49,9 @@ import com.android.messaging.ui.common.components.composer.MESSAGE_COMPOSE_FIELD
 import com.android.messaging.ui.common.components.composer.MessageComposeBar
 import com.android.messaging.ui.common.components.composer.MessageSendButton
 import com.android.messaging.ui.common.components.contentSurfaceShape
+import com.android.messaging.ui.common.components.imeAwareBottomBarInsets
 import com.android.messaging.ui.common.components.mediapreview.MediaPreviewBackground
+import com.android.messaging.ui.common.components.safeDrawingContentPadding
 import com.android.messaging.ui.common.components.selection.LocalSelectionListItemColors
 import com.android.messaging.ui.common.components.selection.SelectionListContent
 import com.android.messaging.ui.common.components.selection.selectionListItemColors
@@ -323,11 +320,10 @@ private fun PickerRecentTargetsContent(
 ) {
     SelectionListContent(
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(
-            start = ScreenContentPadding,
+        contentPadding = safeDrawingContentPadding(
             top = ScreenContentPadding,
-            end = ScreenContentPadding,
             bottom = bottomPadding,
+            horizontal = ScreenContentPadding,
         ),
         canLoadMore = false,
         isLoading = false,
@@ -366,11 +362,10 @@ private fun PickerContactsTargetsContent(
 ) {
     RecipientSelectionContactsContent(
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(
-            start = ScreenContentPadding,
+        contentPadding = safeDrawingContentPadding(
             top = ScreenContentPadding,
-            end = ScreenContentPadding,
             bottom = bottomPadding,
+            horizontal = ScreenContentPadding,
         ),
         uiState = uiState.asRecipientSelectionState(),
         emptyStateText = labels.emptyStateText,
@@ -545,9 +540,7 @@ private fun PickerReviewContent(
             PickerReviewComposeBar(
                 uiState = uiState,
                 onAction = onAction,
-                modifier = Modifier.windowInsetsPadding(
-                    WindowInsets.ime.union(WindowInsets.navigationBars),
-                ),
+                modifier = Modifier.windowInsetsPadding(imeAwareBottomBarInsets()),
             )
         }
     }

--- a/src/com/android/messaging/ui/conversationsettings/screen/ConversationSettingsScreen.kt
+++ b/src/com/android/messaging/ui/conversationsettings/screen/ConversationSettingsScreen.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -55,7 +53,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -67,7 +64,7 @@ import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.messaging.R
-import com.android.messaging.ui.common.components.horizontalSafeDrawingInsets
+import com.android.messaging.ui.common.components.safeDrawingContentPadding
 import com.android.messaging.ui.common.text.asLtrText
 import com.android.messaging.ui.conversation.ConversationActivity
 import com.android.messaging.ui.conversation.conversationSettingsParticipantRowTestTag
@@ -332,17 +329,13 @@ private fun ConversationSettingsList(
     onRequestBlockConfirmation: () -> Unit,
     onRequestSnoozeChooser: () -> Unit,
 ) {
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalInsets = horizontalSafeDrawingInsets()
-
     LazyColumn(
         state = listState,
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(
+        contentPadding = safeDrawingContentPadding(
             top = contentPadding.calculateTopPadding(),
             bottom = contentPadding.calculateBottomPadding() + ScreenContentPadding,
-            start = ScreenContentPadding + horizontalInsets.calculateStartPadding(layoutDirection),
-            end = ScreenContentPadding + horizontalInsets.calculateEndPadding(layoutDirection),
+            horizontal = ScreenContentPadding,
         ),
         verticalArrangement = Arrangement.spacedBy(SectionSpacing),
     ) {

--- a/src/com/android/messaging/ui/photoviewer/component/PhotoViewerMetadataSheet.kt
+++ b/src/com/android/messaging/ui/photoviewer/component/PhotoViewerMetadataSheet.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.FileDownload
@@ -32,6 +32,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.R
 import com.android.messaging.data.media.model.PhotoViewerItem
+import com.android.messaging.ui.common.components.bottomBarInsets
 import com.android.messaging.ui.core.MessagingPreviewTheme
 import com.android.messaging.ui.photoviewer.PHOTO_VIEWER_METADATA_RECEIVED_TIMESTAMP_TEST_TAG
 import com.android.messaging.ui.photoviewer.PHOTO_VIEWER_METADATA_SENDER_TEST_TAG
@@ -98,7 +99,7 @@ private fun PhotoViewerMetadataSheetContent(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .navigationBarsPadding()
+            .windowInsetsPadding(bottomBarInsets())
             .padding(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 24.dp),
         verticalArrangement = Arrangement.spacedBy(space = 24.dp),
     ) {

--- a/src/com/android/messaging/ui/photoviewer/screen/PhotoViewerContent.kt
+++ b/src/com/android/messaging/ui/photoviewer/screen/PhotoViewerContent.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.android.messaging.data.media.model.PhotoViewerItem
 import com.android.messaging.ui.common.components.PagerIndicator
+import com.android.messaging.ui.common.components.bottomBarInsets
 import com.android.messaging.ui.common.components.mediapreview.MediaPreviewBackground
 import com.android.messaging.ui.common.components.mediapreview.MediaPreviewItem
 import com.android.messaging.ui.photoviewer.PHOTO_VIEWER_PAGE_INDICATOR_TEST_TAG
@@ -220,7 +221,7 @@ private fun PhotoViewerMediaContent(
             PagerIndicator(
                 modifier = Modifier
                     .align(alignment = Alignment.BottomCenter)
-                    .navigationBarsPadding()
+                    .windowInsetsPadding(bottomBarInsets())
                     .padding(bottom = PhotoViewerPageIndicatorBottomPadding)
                     .testTag(tag = PHOTO_VIEWER_PAGE_INDICATOR_TEST_TAG),
                 pagerState = pagerState,

--- a/src/com/android/messaging/ui/recipientselection/component/RecipientSelectionContactsContent.kt
+++ b/src/com/android/messaging/ui/recipientselection/component/RecipientSelectionContactsContent.kt
@@ -16,9 +16,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.android.messaging.ui.common.components.PrimaryActionButton
+import com.android.messaging.ui.common.components.bottomBarInsets
 import com.android.messaging.ui.common.components.selection.SelectionListContent
 import com.android.messaging.ui.core.MessagingPreviewColumn
 import com.android.messaging.ui.recipientselection.model.section.RecipientContactListEntry
@@ -92,7 +93,7 @@ internal fun RecipientSelectionContactsContent(
         floatingActionContent = {
             PrimaryActionButton(
                 modifier = Modifier
-                    .navigationBarsPadding()
+                    .windowInsetsPadding(bottomBarInsets())
                     .padding(end = 8.dp, bottom = 8.dp),
                 enabled = primaryAction?.isEnabled ?: false,
                 isLoading = primaryAction?.isLoading ?: false,

--- a/src/com/android/messaging/ui/vcarddetail/screen/VCardDetailScreen.kt
+++ b/src/com/android/messaging/ui/vcarddetail/screen/VCardDetailScreen.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -21,7 +19,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
@@ -30,7 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.messaging.data.vcarddetail.model.VCardFieldAction
 import com.android.messaging.ui.common.components.contentSurfaceShape
-import com.android.messaging.ui.common.components.horizontalSafeDrawingInsets
+import com.android.messaging.ui.common.components.safeDrawingContentPadding
 import com.android.messaging.ui.core.MessagingPreviewTheme
 import com.android.messaging.ui.vcarddetail.common.VCardContactCard
 import com.android.messaging.ui.vcarddetail.common.VCardDetailTopAppBar
@@ -122,17 +119,13 @@ private fun VCardContactList(
     onAction: (Action) -> Unit,
     scaffoldContentPadding: PaddingValues,
 ) {
-    val layoutDirection = LocalLayoutDirection.current
-    val horizontalInsets = horizontalSafeDrawingInsets()
-
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(CardSpacing),
-        contentPadding = PaddingValues(
+        contentPadding = safeDrawingContentPadding(
             top = ScreenContentPadding,
             bottom = ScreenContentPadding + scaffoldContentPadding.calculateBottomPadding(),
-            start = ScreenContentPadding + horizontalInsets.calculateStartPadding(layoutDirection),
-            end = ScreenContentPadding + horizontalInsets.calculateEndPadding(layoutDirection),
+            horizontal = ScreenContentPadding,
         ),
     ) {
         items(


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/Messaging/issues/174

Fixes content running under the camera cutout and the navigation bar in landscape on the conversation picker and the message composers, and extracts the shared window inset helpers the other screens were duplicating.

Guarded by a detekt rule that forbids `navigationBarsPadding()`; it needs type resolution, so CI now runs `:app:detektDebug` instead of `:app:detekt`.