### PR TITLE
Add shared Navigation 3 foundation

### DIFF
--- a/app/src/test/kotlin/com/android/messaging/ui/conversation/messagedetails/MessageDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/conversation/messagedetails/MessageDetailsViewModelTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
 
@@ -45,7 +46,7 @@ internal class MessageDetailsViewModelTest {
     }
 
     @Test
-    fun onArguments_loadsMessageDetailsAndExposesMappedState() = runTest {
+    fun uiState_loadsMessageDetailsFromSeededIdsAndExposesMappedState() = runTest {
         val message = mockk<ConversationMessageData>()
         val details = mockk<ConversationMessageDetails>()
         val content = mockk<MessageDetailsUiState.Content>()
@@ -69,10 +70,6 @@ internal class MessageDetailsViewModelTest {
         } returns content
 
         val viewModel = createViewModel()
-        viewModel.onArguments(
-            conversationId = ConversationId("c"),
-            messageId = MessageId("m"),
-        )
         advanceUntilIdle()
 
         assertEquals(content, viewModel.uiState.value)
@@ -92,7 +89,7 @@ internal class MessageDetailsViewModelTest {
     }
 
     @Test
-    fun onArguments_whenMapperReturnsUnavailable_exposesUnavailable() = runTest {
+    fun uiState_whenMapperReturnsUnavailable_exposesUnavailable() = runTest {
         coEvery {
             conversationsRepository.getMessageDetails(
                 conversationId = ConversationId("c"),
@@ -109,31 +106,29 @@ internal class MessageDetailsViewModelTest {
         } returns MessageDetailsUiState.Unavailable
 
         val viewModel = createViewModel()
-        viewModel.onArguments(
-            conversationId = ConversationId("c"),
-            messageId = MessageId("m"),
-        )
         advanceUntilIdle()
 
         assertEquals(MessageDetailsUiState.Unavailable, viewModel.uiState.value)
     }
 
     @Test
-    fun onArguments_storesArgumentsInSavedStateHandle() {
-        val savedStateHandle = SavedStateHandle()
-        val viewModel = createViewModel(savedStateHandle)
-
-        viewModel.onArguments(
-            conversationId = ConversationId("c"),
-            messageId = MessageId("m"),
+    fun construction_whenConversationIdMissing_throws() {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(MESSAGE_DETAILS_MESSAGE_ID_ARG to "m"),
         )
 
-        assertEquals("c", savedStateHandle.get<String?>("conversation_id"))
-        assertEquals("m", savedStateHandle.get<String?>("message_id"))
+        assertThrows(IllegalArgumentException::class.java) {
+            createViewModel(savedStateHandle)
+        }
     }
 
     private fun createViewModel(
-        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        savedStateHandle: SavedStateHandle = SavedStateHandle(
+            mapOf(
+                MESSAGE_DETAILS_CONVERSATION_ID_ARG to "c",
+                MESSAGE_DETAILS_MESSAGE_ID_ARG to "m",
+            ),
+        ),
     ): MessageDetailsViewModel {
         return MessageDetailsViewModel(
             conversationsRepository = conversationsRepository,

--- a/app/src/test/kotlin/com/android/messaging/ui/navigation/NavKeySerializationTest.kt
+++ b/app/src/test/kotlin/com/android/messaging/ui/navigation/NavKeySerializationTest.kt
@@ -1,0 +1,72 @@
+package com.android.messaging.ui.navigation
+
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.serialization.NavKeySerializer
+import androidx.savedstate.serialization.decodeFromSavedState
+import androidx.savedstate.serialization.encodeToSavedState
+import com.android.messaging.data.conversation.model.ConversationId
+import com.android.messaging.data.conversation.model.MessageId
+import com.android.messaging.ui.conversation.navigation.AddParticipantsNavKey
+import com.android.messaging.ui.conversation.navigation.ConversationNavKey
+import com.android.messaging.ui.conversation.navigation.MessageDetailsNavKey
+import com.android.messaging.ui.conversation.navigation.NewChatNavKey
+import com.android.messaging.ui.conversation.navigation.RecipientPickerMode
+import com.android.messaging.ui.conversation.navigation.RecipientPickerNavKey
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NavKeySerializationTest {
+
+    private val serializer = NavKeySerializer<NavKey>()
+
+    @Test
+    fun conversationGraphNavKey_roundTripsThroughSavedState() {
+        assertRoundTrips(ConversationGraphNavKey)
+    }
+
+    @Test
+    fun newChatNavKey_roundTripsThroughSavedState() {
+        assertRoundTrips(NewChatNavKey)
+    }
+
+    @Test
+    fun conversationNavKey_roundTripsWithTypedConversationId() {
+        assertRoundTrips(ConversationNavKey(conversationId = ConversationId("c")))
+    }
+
+    @Test
+    fun addParticipantsNavKey_roundTripsWithTypedConversationId() {
+        assertRoundTrips(AddParticipantsNavKey(conversationId = ConversationId("c")))
+    }
+
+    @Test
+    fun messageDetailsNavKey_roundTripsWithTypedIds() {
+        assertRoundTrips(
+            MessageDetailsNavKey(
+                conversationId = ConversationId("c"),
+                messageId = MessageId("m"),
+            ),
+        )
+    }
+
+    @Test
+    fun recipientPickerNavKey_roundTripsWithMode() {
+        assertRoundTrips(RecipientPickerNavKey(mode = RecipientPickerMode.ADD_PARTICIPANTS))
+    }
+
+    private fun assertRoundTrips(navKey: NavKey) {
+        val encoded = encodeToSavedState(
+            serializer = serializer,
+            value = navKey,
+        )
+        val restored = decodeFromSavedState(
+            deserializer = serializer,
+            savedState = encoded,
+        )
+
+        assertEquals(navKey, restored)
+    }
+}

--- a/src/com/android/messaging/ui/conversation/messagedetails/MessageDetailsScreen.kt
+++ b/src/com/android/messaging/ui/conversation/messagedetails/MessageDetailsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,8 +29,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.android.messaging.R
-import com.android.messaging.data.conversation.model.ConversationId
-import com.android.messaging.data.conversation.model.MessageId
 import com.android.messaging.data.conversation.model.message.ConversationMessageDetails
 import com.android.messaging.ui.conversation.messagedetails.model.MessageDetailsUiState
 import com.android.messaging.ui.conversation.preview.previewIncomingMessage
@@ -40,20 +37,11 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun MessageDetailsScreen(
-    conversationId: ConversationId,
-    messageId: MessageId,
     modifier: Modifier = Modifier,
     onNavigateBack: () -> Unit = {},
     screenModel: MessageDetailsScreenModel = hiltViewModel<MessageDetailsViewModel>(),
 ) {
     val uiState by screenModel.uiState.collectAsStateWithLifecycle()
-
-    LaunchedEffect(conversationId, messageId, screenModel) {
-        screenModel.onArguments(
-            conversationId = conversationId,
-            messageId = messageId,
-        )
-    }
 
     MessageDetailsScaffold(
         uiState = uiState,

--- a/src/com/android/messaging/ui/conversation/messagedetails/MessageDetailsViewModel.kt
+++ b/src/com/android/messaging/ui/conversation/messagedetails/MessageDetailsViewModel.kt
@@ -16,14 +16,13 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+
+internal const val MESSAGE_DETAILS_CONVERSATION_ID_ARG = "conversationId"
+internal const val MESSAGE_DETAILS_MESSAGE_ID_ARG = "messageId"
 
 internal interface MessageDetailsScreenModel {
     val uiState: StateFlow<State>
-
-    fun onArguments(conversationId: ConversationId, messageId: MessageId)
 
     fun onCopy(value: String)
 }
@@ -34,19 +33,20 @@ internal class MessageDetailsViewModel @Inject constructor(
     private val appSettingsRepository: AppSettingsRepository,
     private val messageDetailsUiStateMapper: MessageDetailsUiStateMapper,
     private val clipboardManager: ClipboardManager,
-    private val savedStateHandle: SavedStateHandle,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel(),
     MessageDetailsScreenModel {
 
     private val _uiState = MutableStateFlow<State>(State.Loading)
     override val uiState = _uiState.asStateFlow()
 
-    private val conversationIdFlow: MutableStateFlow<ConversationId?> = MutableStateFlow(
-        ConversationId.fromOrNull(savedStateHandle[CONVERSATION_ID_KEY]),
-    )
-    private val messageIdFlow: MutableStateFlow<MessageId?> = MutableStateFlow(
-        MessageId.fromOrNull(savedStateHandle[MESSAGE_ID_KEY]),
-    )
+    private val conversationId: ConversationId = requireNotNull(
+        ConversationId.fromOrNull(savedStateHandle[MESSAGE_DETAILS_CONVERSATION_ID_ARG]),
+    ) { "conversationId is required" }
+
+    private val messageId: MessageId = requireNotNull(
+        MessageId.fromOrNull(savedStateHandle[MESSAGE_DETAILS_MESSAGE_ID_ARG]),
+    ) { "messageId is required" }
 
     init {
         bindMessageDetails()
@@ -54,31 +54,7 @@ internal class MessageDetailsViewModel @Inject constructor(
 
     private fun bindMessageDetails() {
         viewModelScope.launch {
-            combine(
-                conversationIdFlow,
-                messageIdFlow,
-            ) { conversationId, messageId ->
-                MessageDetailsArguments(
-                    conversationId = conversationId,
-                    messageId = messageId,
-                )
-            }.collectLatest { arguments ->
-                _uiState.value = loadMessageDetails(arguments)
-            }
-        }
-    }
-
-    override fun onArguments(
-        conversationId: ConversationId,
-        messageId: MessageId,
-    ) {
-        if (conversationIdFlow.value != conversationId) {
-            conversationIdFlow.value = conversationId
-            savedStateHandle[CONVERSATION_ID_KEY] = conversationId.value
-        }
-        if (messageIdFlow.value != messageId) {
-            messageIdFlow.value = messageId
-            savedStateHandle[MESSAGE_ID_KEY] = messageId.value
+            _uiState.value = loadMessageDetails()
         }
     }
 
@@ -86,14 +62,7 @@ internal class MessageDetailsViewModel @Inject constructor(
         clipboardManager.setPrimaryClip(ClipData.newPlainText(null, value))
     }
 
-    private suspend fun loadMessageDetails(arguments: MessageDetailsArguments): State {
-        val conversationId = arguments.conversationId
-        val messageId = arguments.messageId
-
-        if (conversationId == null || messageId == null) {
-            return State.Loading
-        }
-
+    private suspend fun loadMessageDetails(): State {
         val result = conversationsRepository.getMessageDetails(
             conversationId = conversationId,
             messageId = messageId,
@@ -104,15 +73,5 @@ internal class MessageDetailsViewModel @Inject constructor(
             details = result?.details,
             youTubeLinkPreviewsEnabled = appSettingsRepository.isYouTubeLinkPreviewsEnabled(),
         )
-    }
-
-    private data class MessageDetailsArguments(
-        val conversationId: ConversationId?,
-        val messageId: MessageId?,
-    )
-
-    private companion object {
-        private const val CONVERSATION_ID_KEY = "conversation_id"
-        private const val MESSAGE_ID_KEY = "message_id"
     }
 }

--- a/src/com/android/messaging/ui/conversation/navigation/ConversationNavDefaultArgs.kt
+++ b/src/com/android/messaging/ui/conversation/navigation/ConversationNavDefaultArgs.kt
@@ -1,0 +1,12 @@
+package com.android.messaging.ui.conversation.navigation
+
+import android.os.Bundle
+import com.android.messaging.ui.conversation.messagedetails.MESSAGE_DETAILS_CONVERSATION_ID_ARG
+import com.android.messaging.ui.conversation.messagedetails.MESSAGE_DETAILS_MESSAGE_ID_ARG
+
+internal fun messageDetailsDefaultArgs(navKey: MessageDetailsNavKey): Bundle {
+    return Bundle().apply {
+        putString(MESSAGE_DETAILS_CONVERSATION_ID_ARG, navKey.conversationId.value)
+        putString(MESSAGE_DETAILS_MESSAGE_ID_ARG, navKey.messageId.value)
+    }
+}

--- a/src/com/android/messaging/ui/conversation/navigation/ConversationNavGraph.kt
+++ b/src/com/android/messaging/ui/conversation/navigation/ConversationNavGraph.kt
@@ -1,7 +1,5 @@
 package com.android.messaging.ui.conversation.navigation
 
-import androidx.compose.foundation.background
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
@@ -13,13 +11,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
-import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.ui.NavDisplay
 import com.android.messaging.data.conversation.model.ConversationId
 import com.android.messaging.data.conversation.model.ParticipantId
 import com.android.messaging.data.conversation.model.draft.ConversationDraft
@@ -33,6 +28,8 @@ import com.android.messaging.ui.conversation.entry.model.ConversationEntryUiStat
 import com.android.messaging.ui.conversation.messagedetails.MessageDetailsScreen
 import com.android.messaging.ui.conversation.recipientpicker.RecipientPickerScreen
 import com.android.messaging.ui.conversation.screen.ConversationScreen
+import com.android.messaging.ui.navigation.AppNavDisplay
+import com.android.messaging.ui.navigation.SeededViewModelStoreOwner
 
 @Composable
 internal fun ConversationNavGraph(
@@ -61,10 +58,6 @@ internal fun ConversationNavGraph(
         ),
         onFinish = rememberUpdatedState(newValue = onFinish),
     )
-    val entryDecorators = listOf(
-        rememberSaveableStateHolderNavEntryDecorator(),
-        rememberViewModelStoreNavEntryDecorator<NavKey>(),
-    )
     val entryProvider = remember(backStack) {
         conversationNavEntryProvider(routeState = routeState)
     }
@@ -87,9 +80,9 @@ internal fun ConversationNavGraph(
         },
     )
 
-    NavDisplay(
+    AppNavDisplay(
         backStack = backStack,
-        modifier = modifier.background(color = MaterialTheme.colorScheme.background),
+        entryProvider = entryProvider,
         onBack = {
             handleNavBack(
                 backStack = backStack,
@@ -97,8 +90,7 @@ internal fun ConversationNavGraph(
                 onFinish = onFinish,
             )
         },
-        entryDecorators = entryDecorators,
-        entryProvider = entryProvider,
+        modifier = modifier,
     )
 }
 
@@ -240,17 +232,21 @@ private fun messageDetailsRouteContent(
     routeState: ConversationNavRouteState,
 ): @Composable (MessageDetailsNavKey) -> Unit {
     return { navKey ->
-        MessageDetailsScreen(
-            conversationId = navKey.conversationId,
-            messageId = navKey.messageId,
-            onNavigateBack = {
-                popBackStackOrFinish(
-                    backStack = routeState.backStack,
-                    navigationReducer = routeState.navigationReducer.value,
-                    onFinish = routeState.onFinish.value,
-                )
-            },
-        )
+        val defaultArgs = remember(navKey) {
+            messageDetailsDefaultArgs(navKey = navKey)
+        }
+
+        SeededViewModelStoreOwner(defaultArgs = defaultArgs) {
+            MessageDetailsScreen(
+                onNavigateBack = {
+                    popBackStackOrFinish(
+                        backStack = routeState.backStack,
+                        navigationReducer = routeState.navigationReducer.value,
+                        onFinish = routeState.onFinish.value,
+                    )
+                },
+            )
+        }
     }
 }
 

--- a/src/com/android/messaging/ui/conversation/navigation/ConversationNavigationReducer.kt
+++ b/src/com/android/messaging/ui/conversation/navigation/ConversationNavigationReducer.kt
@@ -3,6 +3,8 @@ package com.android.messaging.ui.conversation.navigation
 import androidx.navigation3.runtime.NavKey
 import com.android.messaging.data.conversation.model.ConversationId
 import com.android.messaging.data.conversation.model.MessageId
+import com.android.messaging.ui.navigation.NavigationReducer
+import com.android.messaging.ui.navigation.NavigationReducerImpl
 
 internal interface ConversationNavigationReducer {
     fun navigateToAddParticipants(
@@ -39,15 +41,18 @@ internal interface ConversationNavigationReducer {
     )
 }
 
-internal class ConversationNavigationReducerImpl : ConversationNavigationReducer {
+internal class ConversationNavigationReducerImpl(
+    private val navigationReducer: NavigationReducer = NavigationReducerImpl(),
+) : ConversationNavigationReducer {
 
     override fun navigateToAddParticipants(
         backStack: MutableList<NavKey>,
         conversationId: ConversationId,
     ) {
-        AddParticipantsNavKey(conversationId = conversationId)
-            .takeIf { it != backStack.lastOrNull() }
-            ?.let(backStack::add)
+        navigationReducer.push(
+            backStack = backStack,
+            destination = AddParticipantsNavKey(conversationId = conversationId),
+        )
     }
 
     override fun navigateToConversation(
@@ -56,13 +61,10 @@ internal class ConversationNavigationReducerImpl : ConversationNavigationReducer
     ) {
         removeTrailingConversationEntryDestinations(backStack = backStack)
 
-        val destination = ConversationNavKey(conversationId = conversationId)
-
-        if (destination == backStack.lastOrNull()) {
-            return
-        }
-
-        backStack.add(destination)
+        navigationReducer.push(
+            backStack = backStack,
+            destination = ConversationNavKey(conversationId = conversationId),
+        )
     }
 
     override fun navigateToMessageDetails(
@@ -70,30 +72,27 @@ internal class ConversationNavigationReducerImpl : ConversationNavigationReducer
         conversationId: ConversationId,
         messageId: MessageId,
     ) {
-        MessageDetailsNavKey(
-            conversationId = conversationId,
-            messageId = messageId,
+        navigationReducer.push(
+            backStack = backStack,
+            destination = MessageDetailsNavKey(
+                conversationId = conversationId,
+                messageId = messageId,
+            ),
         )
-            .takeIf { it != backStack.lastOrNull() }
-            ?.let(backStack::add)
     }
 
     override fun navigateToRecipientPicker(
         backStack: MutableList<NavKey>,
         mode: RecipientPickerMode,
     ) {
-        RecipientPickerNavKey(mode = mode)
-            .takeIf { it != backStack.lastOrNull() }
-            ?.let(backStack::add)
+        navigationReducer.push(
+            backStack = backStack,
+            destination = RecipientPickerNavKey(mode = mode),
+        )
     }
 
     override fun popBackStack(backStack: MutableList<NavKey>): Boolean {
-        if (backStack.size <= 1) {
-            return false
-        }
-
-        backStack.removeAt(backStack.lastIndex)
-        return true
+        return navigationReducer.pop(backStack = backStack)
     }
 
     override fun replaceCurrentConversation(
@@ -121,12 +120,10 @@ internal class ConversationNavigationReducerImpl : ConversationNavigationReducer
         backStack: MutableList<NavKey>,
         destination: NavKey,
     ) {
-        if (backStack.size == 1 && backStack.firstOrNull() == destination) {
-            return
-        }
-
-        backStack.clear()
-        backStack.add(destination)
+        navigationReducer.reset(
+            backStack = backStack,
+            destination = destination,
+        )
     }
 
     private fun removeTrailingConversationEntryDestinations(backStack: MutableList<NavKey>) {

--- a/src/com/android/messaging/ui/navigation/AppNavDisplay.kt
+++ b/src/com/android/messaging/ui/navigation/AppNavDisplay.kt
@@ -1,0 +1,38 @@
+package com.android.messaging.ui.navigation
+
+import androidx.compose.foundation.background
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SinglePaneSceneStrategy
+import androidx.navigation3.ui.NavDisplay
+
+@Composable
+internal fun AppNavDisplay(
+    backStack: MutableList<NavKey>,
+    entryProvider: (NavKey) -> NavEntry<NavKey>,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    sceneStrategy: SceneStrategy<NavKey> = SinglePaneSceneStrategy(),
+) {
+    val entryDecorators = listOf(
+        rememberSaveableStateHolderNavEntryDecorator(),
+        rememberViewModelStoreNavEntryDecorator<NavKey>(),
+    )
+
+    NavDisplay(
+        backStack = backStack,
+        modifier = modifier.background(
+            color = MaterialTheme.colorScheme.background,
+        ),
+        onBack = { onBack() },
+        entryDecorators = entryDecorators,
+        sceneStrategies = listOf(sceneStrategy),
+        entryProvider = entryProvider,
+    )
+}

--- a/src/com/android/messaging/ui/navigation/ConversationGraphNavKey.kt
+++ b/src/com/android/messaging/ui/navigation/ConversationGraphNavKey.kt
@@ -1,0 +1,7 @@
+package com.android.messaging.ui.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data object ConversationGraphNavKey : NavKey

--- a/src/com/android/messaging/ui/navigation/NavigationReducer.kt
+++ b/src/com/android/messaging/ui/navigation/NavigationReducer.kt
@@ -1,0 +1,73 @@
+package com.android.messaging.ui.navigation
+
+import androidx.navigation3.runtime.NavKey
+
+internal interface NavigationReducer {
+
+    fun push(
+        backStack: MutableList<NavKey>,
+        destination: NavKey,
+    )
+
+    fun pop(
+        backStack: MutableList<NavKey>,
+    ): Boolean
+
+    fun replaceTop(
+        backStack: MutableList<NavKey>,
+        destination: NavKey,
+    )
+
+    fun reset(
+        backStack: MutableList<NavKey>,
+        destination: NavKey,
+    )
+}
+
+internal class NavigationReducerImpl : NavigationReducer {
+
+    override fun push(
+        backStack: MutableList<NavKey>,
+        destination: NavKey,
+    ) {
+        destination
+            .takeIf { it != backStack.lastOrNull() }
+            ?.let(backStack::add)
+    }
+
+    override fun pop(
+        backStack: MutableList<NavKey>,
+    ): Boolean {
+        if (backStack.size <= 1) {
+            return false
+        }
+
+        backStack.removeAt(backStack.lastIndex)
+
+        return true
+    }
+
+    override fun replaceTop(
+        backStack: MutableList<NavKey>,
+        destination: NavKey,
+    ) {
+        if (backStack.isEmpty()) {
+            backStack.add(destination)
+            return
+        }
+
+        backStack[backStack.lastIndex] = destination
+    }
+
+    override fun reset(
+        backStack: MutableList<NavKey>,
+        destination: NavKey,
+    ) {
+        if (backStack.size == 1 && backStack.firstOrNull() == destination) {
+            return
+        }
+
+        backStack.clear()
+        backStack.add(destination)
+    }
+}

--- a/src/com/android/messaging/ui/navigation/SeededViewModelStoreOwner.kt
+++ b/src/com/android/messaging/ui/navigation/SeededViewModelStoreOwner.kt
@@ -1,0 +1,58 @@
+package com.android.messaging.ui.navigation
+
+import android.os.Bundle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.lifecycle.DEFAULT_ARGS_KEY
+import androidx.lifecycle.HasDefaultViewModelProviderFactory
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.MutableCreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+
+@Composable
+internal fun SeededViewModelStoreOwner(
+    defaultArgs: Bundle,
+    content: @Composable () -> Unit,
+) {
+    val parentOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "Missing ViewModelStoreOwner"
+    }
+
+    require(parentOwner is HasDefaultViewModelProviderFactory) {
+        "Owner has no default extras"
+    }
+
+    val seededOwner = remember(parentOwner, defaultArgs) {
+        seededViewModelStoreOwner(
+            parentOwner = parentOwner,
+            defaultArgs = defaultArgs,
+        )
+    }
+
+    CompositionLocalProvider(LocalViewModelStoreOwner provides seededOwner) {
+        content()
+    }
+}
+
+private fun <T> seededViewModelStoreOwner(
+    parentOwner: T,
+    defaultArgs: Bundle,
+): ViewModelStoreOwner where T : ViewModelStoreOwner, T : HasDefaultViewModelProviderFactory {
+    return object : ViewModelStoreOwner, HasDefaultViewModelProviderFactory {
+
+        override val viewModelStore: ViewModelStore
+            get() = parentOwner.viewModelStore
+
+        override val defaultViewModelProviderFactory: ViewModelProvider.Factory
+            get() = parentOwner.defaultViewModelProviderFactory
+
+        override val defaultViewModelCreationExtras: CreationExtras
+            get() = MutableCreationExtras(parentOwner.defaultViewModelCreationExtras).apply {
+                this[DEFAULT_ARGS_KEY] = defaultArgs
+            }
+    }
+}


### PR DESCRIPTION
Closes #220

Adds shared Navigation 3 pieces: `AppNavDisplay`, a `NavigationReducer` for back stack edits, and a `SeededViewModelStoreOwner` that puts `NavKey` arguments into `SavedStateHandle`. The conversation subgraph now uses them, and `MessageDetailsViewModel` reads its `ids` from `SavedStateHandle` instead of `onArguments()`.